### PR TITLE
Overhaul slash command parser to have argument specification

### DIFF
--- a/server/commands/__init__.py
+++ b/server/commands/__init__.py
@@ -1,3 +1,275 @@
+import functools
+import inspect
+import shlex
+
+from ..exceptions import ArgumentError
+
+
+_UNSET = object()
+
+
+def tokens_str(text):
+    """Shlex-split and rejoin text, unquoting quoted words while keeping
+    spaces. Used as a `rest` arg converter for commands that previously did
+    `\" \".join(shlex.split(arg))`.
+    """
+    return " ".join(shlex.split(text))
+
+
+class Arg:
+    """Declare one positional argument of an `ooc_cmd_*` command.
+
+    Arguments bind left-to-right to the tokens of the raw command line,
+    shlex-style (double/single quotes and backslash escapes are honored, so
+    values containing spaces can be quoted). Required arguments must come
+    first; once an argument with a `default` appears, every later argument
+    must also provide one. At most one `rest`/`variadic` argument is allowed
+    and it must be the last one.
+
+    :param name: Parameter name; the command function receives the parsed
+        value under this keyword and error messages reference it.
+    :param type: Converter applied to the raw token(s). `str`, `int` and
+        `bool` (on/off/true/false/1/0/yes/no) are handled natively; any
+        other callable is used as a custom converter.
+    :param choices: Sequence of allowed input values; matching is
+        case-insensitive and the matched entry (canonical casing/type) is
+        returned.
+    :param default: Value used when the user omits the argument. Providing a
+        default makes the argument optional.
+    :param rest: Capture the rest of the line, un-split (whitespace and
+        quoting preserved), as a single string. Only valid as the last
+        argument.
+    :param variadic: Collect every remaining token into a list, converting
+        each one with `type`. Only valid as the last argument.
+    """
+
+    def __init__(
+        self,
+        name,
+        type=str,
+        *,
+        required=None,
+        default=_UNSET,
+        choices=None,
+        rest=False,
+        variadic=False,
+        help=None,    ):
+        if rest and variadic:
+            raise ValueError(f"Arg '{name}' cannot be both rest and variadic.")
+        if default is not _UNSET and required:
+            raise ValueError(
+                f"Arg '{name}' cannot be both required and have a default."
+            )
+        self.name = name
+        self.type = type
+        self.required = required if required is not None else default is _UNSET
+        self.default = default if default is not _UNSET else None
+        self.choices = choices
+        self.rest = rest
+        self.variadic = variadic
+        self.help = help
+
+
+_TRUE_VALUES = {"true", "on", "1", "yes"}
+_FALSE_VALUES = {"false", "off", "0", "no"}
+
+
+def _tokenize(arg):
+    """Shlex-style tokenizer that also records each token's character span.
+
+    Returns a list of `(token, start, end)` tuples. The quoting rules mirror
+    `shlex.split(posix=True)` closely enough for chat input, while exposing
+    token positions so `rest` arguments can capture the untouched remainder.
+    """
+    tokens = []
+    i, n = 0, len(arg)
+    while i < n:
+        while i < n and arg[i].isspace():
+            i += 1
+        if i >= n:
+            break
+        start = i
+        out = []
+        while i < n and not arg[i].isspace():
+            ch = arg[i]
+            if ch in ('"', "'"):
+                quote = ch
+                i += 1
+                while i < n:
+                    c = arg[i]
+                    if c == quote:
+                        i += 1
+                        break
+                    if c == "\\" and i + 1 < n:
+                        out.append(arg[i + 1])
+                        i += 2
+                    else:
+                        out.append(c)
+                        i += 1
+            elif ch == "\\" and i + 1 < n:
+                out.append(arg[i + 1])
+                i += 2
+            else:
+                out.append(ch)
+                i += 1
+        tokens.append(("".join(out), start, i))
+    return tokens
+
+
+def _msg(why, usage):
+    return f"{why} {usage}" if usage else why
+
+
+def _parse_bool(name, raw):
+    lowered = raw.lower()
+    if lowered in _TRUE_VALUES:
+        return True
+    if lowered in _FALSE_VALUES:
+        return False
+    raise ArgumentError(
+        f"Invalid value for {name} ('{raw}'). Expected on/off (or true/false/1/0)."
+    )
+
+
+def _convert(name, raw, spec, usage):
+    if spec.choices is not None:
+        for choice in spec.choices:
+            if str(raw).lower() == str(choice).lower():
+                return choice
+        expected = ", ".join(f"'{c}'" for c in spec.choices)
+        raise ArgumentError(
+            _msg(
+                f"Invalid value for {name} ('{raw}'). Expected one of: {expected}.",
+                usage,
+            )
+        )
+    try:
+        if spec.type is bool:
+            return _parse_bool(name, raw)
+        if spec.type is int:
+            return int(raw)
+        if spec.type is str:
+            return raw
+        return spec.type(raw)
+    except (ValueError, TypeError):
+        if spec.type is int:
+            raise ArgumentError(_msg(f"{name} must be a number.", usage))
+        raise ArgumentError(_msg(f"Invalid value for {name} ('{raw}').", usage))
+
+
+def parse_command_args(raw, args, usage=""):
+    """Parse a raw command line against an argument spec.
+
+    Returns a dict mapping each declared argument name to its parsed value.
+    Raises `ArgumentError` (including the command's usage line when one is
+    known) on missing, extra or invalid arguments.
+    """
+    if not isinstance(raw, str):
+        raw = "" if raw is None else str(raw)
+    if not args:
+        if raw.strip():
+            raise ArgumentError(_msg("This command takes no arguments.", usage))
+        return {}
+
+    tokens = _tokenize(raw)
+    consumed = 0
+    values = {}
+    for spec in args:
+        if spec.rest:
+            if consumed == 0:
+                rest = raw
+            else:
+                rest = raw[tokens[consumed - 1][2]:]
+            if spec.type is str:
+                values[spec.name] = rest.strip()
+            else:
+                values[spec.name] = _convert(spec.name, rest, spec, usage)
+            consumed = len(tokens)
+            break
+        if spec.variadic:
+            remaining = tokens[consumed:]
+            if not remaining:
+                if spec.required:
+                    raise ArgumentError(_msg("Not enough arguments.", usage))
+                values[spec.name] = spec.default
+            else:
+                values[spec.name] = [
+                    _convert(spec.name, token[0], spec, usage) for token in remaining
+                ]
+            consumed = len(tokens)
+            break
+        if consumed < len(tokens):
+            values[spec.name] = _convert(spec.name, tokens[consumed][0], spec, usage)
+            consumed += 1
+        elif spec.required:
+            raise ArgumentError(_msg("Not enough arguments.", usage))
+        else:
+            values[spec.name] = spec.default
+    if consumed < len(tokens):
+        raise ArgumentError(_msg("Too many arguments.", usage))
+    return values
+
+
+def _extract_usage(func):
+    """Pull the `Usage:` line out of a command's docstring."""
+    doc = inspect.getdoc(func) or ""
+    lines = doc.splitlines()
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.lower().startswith("usage:"):
+            if stripped.lower() == "usage:":
+                for nxt in lines[idx + 1:]:
+                    if nxt.strip():
+                        return f"Usage: {nxt.strip()}"
+                return "Usage:"
+            return stripped
+    return ""
+
+
+def command(*args, usage=None):
+    """Declare the argument spec of an `ooc_cmd_*` function.
+
+    The decorated function keeps its `ooc_cmd_<name>` identity and can still
+    be called the legacy way -- `func(client, raw_arg_string)` -- while its
+    body receives every declared argument as a keyword. Missing/extra
+    arguments and conversion errors raise a standardized `ArgumentError`
+    that includes the docstring's `Usage:` line.
+
+    Use inside `@mod_only(...)`: `@mod_only() @command(...) def ooc_cmd_x(client, ...)`.
+    """
+    specs = [a if isinstance(a, Arg) else Arg(a) for a in args]
+    seen_optional = False
+    for idx, spec in enumerate(specs):
+        if spec.rest or spec.variadic:
+            if idx != len(specs) - 1:
+                raise ValueError(
+                    f"Arg '{spec.name}' must be the last declared argument."
+                )
+        if not spec.required:
+            seen_optional = True
+        elif seen_optional:
+            raise ValueError(
+                f"Required arg '{spec.name}' follows an optional argument."
+            )
+
+    def decorator(func):
+        usage_line = _extract_usage(func) if usage is None else usage
+
+        @functools.wraps(func)
+        def wrapper(client, arg=None, *extra, **kwargs):
+            if isinstance(arg, dict):
+                parsed = dict(arg)
+            else:
+                parsed = parse_command_args(arg, specs, usage_line)
+            return func(client, **parsed)
+
+        wrapper.command_spec = tuple(specs)
+        wrapper.command_usage = usage_line
+        return wrapper
+
+    return decorator
+
+
 def resolve_command(server, cmd):
     """
     Resolve a command name to its `ooc_cmd_<name>` function, following the
@@ -26,13 +298,18 @@ def call(client, cmd, arg):
 
 
 def submodules():
-    """Get all command-related submodules."""
+    """Get all command-related submodules.
+
+    Only modules that actually belong to the `server.commands` package are
+    yielded -- stdlib imports (`functools`, `inspect`, `shlex`) that live at
+    package scope must not show up as help categories.
+    """
     import sys
     import inspect
 
     me = sys.modules[__name__]
     for _, v in inspect.getmembers(me):
-        if inspect.ismodule(v):
+        if inspect.ismodule(v) and v.__name__.startswith(__name__ + "."):
             yield v
 
 

--- a/server/commands/__init__.py
+++ b/server/commands/__init__.py
@@ -324,6 +324,15 @@ def reload():
         for f in m.__all__:
             me.__dict__[f] = m.__dict__[f]
 
+    # The GM panel caches its auto-generated command catalog; drop the cache
+    # so the panel picks up the freshly reloaded command definitions.
+    try:
+        from server.web_view.gm_panel.commands_meta import CommandLister
+
+        CommandLister.invalidate()
+    except ImportError:
+        pass
+
 
 def help(command):
     import sys

--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -8,7 +8,7 @@ from server.constants import TargetType
 from server.exceptions import ClientError, ServerError, ArgumentError
 import asyncio
 
-from . import mod_only, list_commands, list_submodules, help
+from . import mod_only, list_commands, list_submodules, help, Arg, command
 
 __all__ = [
     "ooc_cmd_motd",
@@ -36,24 +36,24 @@ __all__ = [
 ]
 
 
-def ooc_cmd_motd(client, arg):
+@command()
+def ooc_cmd_motd(client):
     """
     Show the message of the day.
     Usage: /motd
     """
-    if len(arg) != 0:
-        raise ArgumentError("This command doesn't take any arguments")
     client.send_motd()
 
 
-def ooc_cmd_help(client, arg):
+@command(Arg("topic", rest=True, default="", help="command or category"))
+def ooc_cmd_help(client, topic):
     """
     Show help for a command, or show general help.
     Usage: /help
     """
     import inspect
 
-    if arg == "":
+    if topic == "":
         msg = inspect.cleandoc(
             """
         Welcome to tsuserver3! You can use /help <command> on any known
@@ -72,7 +72,7 @@ def ooc_cmd_help(client, arg):
         msg += list_submodules()
         client.send_ooc(msg)
     else:
-        arg = arg.lower()
+        arg = topic.lower()
         try:
             if arg in client.server.command_aliases:
                 arg = client.server.command_aliases[arg]
@@ -89,7 +89,11 @@ def ooc_cmd_help(client, arg):
 
 
 @mod_only()
-def ooc_cmd_kick(client, arg):
+@command(
+    Arg("target", help="ipid, *, or **"),
+    Arg("reason", rest=True, default="", help="kick reason"),
+)
+def ooc_cmd_kick(client, target, reason):
     """
     Kick a player.
     Usage: /kick <ipid|*|**> [reason]
@@ -97,29 +101,21 @@ def ooc_cmd_kick(client, arg):
      - "*" kicks everyone in the current area.
      - "**" kicks everyone in the server.
     """
-    if len(arg) == 0:
-        raise ArgumentError(
-            "You must specify a target. Use /kick <ipid> [reason]")
-    elif arg[0] == "*":
+    ipid = None
+    if target == "*":
         targets = [c for c in client.area.clients if c != client]
-    elif arg[0] == "**":
+    elif target == "**":
         targets = [c for c in client.server.client_manager.clients if c != client]
     else:
-        targets = None
-
-    args = list(arg.split(" "))
-    if targets is None:
-        raw_ipid = args[0]
         try:
-            ipid = int(raw_ipid)
-        except Exception:
-            raise ClientError(f"{raw_ipid} does not look like a valid IPID.")
+            ipid = int(target)
+        except ValueError:
+            raise ClientError(f"{target} does not look like a valid IPID.")
         targets = client.server.client_manager.get_targets(
             client, TargetType.IPID, ipid, False
         )
 
     if targets:
-        reason = " ".join(args[1:])
         for c in targets:
             database.log_misc("kick", client, target=c,
                               data={"reason": reason})
@@ -131,7 +127,11 @@ def ooc_cmd_kick(client, arg):
         client.send_ooc(f"No targets with the IPID {ipid} were found.")
 
 
-def ooc_cmd_ban(client, arg):
+@mod_only()
+@command(
+    Arg("args", rest=True, default="", help="<ipid> <reason>/<ban_id> [duration]")
+)
+def ooc_cmd_ban(client, args):
     """
     Ban a user. If a ban ID is specified instead of a reason,
     then the IPID is added to an existing ban record.
@@ -139,19 +139,23 @@ def ooc_cmd_ban(client, arg):
     Usage: /ban <ipid> "reason" ["<N> <minute|hour|day|week|month>(s)|perma"]
     Usage 2: /ban <ipid> <ban_id>
     """
-    kickban(client, arg, False)
+    kickban(client, args, False)
 
 
-def ooc_cmd_banhdid(client, arg):
+@mod_only()
+@command(
+    Arg("args", rest=True, default="", help="<ipid> <reason>/<ban_id> [duration]")
+)
+def ooc_cmd_banhdid(client, args):
     """
     Ban both a user's HDID and IPID.
     Usage: See /ban.
     """
-    kickban(client, arg, True)
+    kickban(client, args, True)
 
 
-@mod_only()
 def kickban(client, arg, ban_hdid):
+    """Shared implementation of /ban and /banhdid."""
     args = shlex.split(arg)
     if len(args) < 2:
         raise ArgumentError("Not enough arguments.")
@@ -218,17 +222,14 @@ def kickban(client, arg, ban_hdid):
 
 
 @mod_only()
-def ooc_cmd_unban(client, arg):
+@command(Arg("ban_ids", variadic=True, type=int, help="one or more ban IDs"))
+def ooc_cmd_unban(client, ban_ids):
     """
     Unban a list of users.
     Usage: /unban <ban_id...>
     """
-    if len(arg) == 0:
-        raise ArgumentError(
-            "You must specify a target. Use /unban <ban_id...>")
-    args = list(arg.split(" "))
-    client.send_ooc(f"Attempting to lift {len(args)} ban(s)...")
-    for ban_id in args:
+    client.send_ooc(f"Attempting to lift {len(ban_ids)} ban(s)...")
+    for ban_id in ban_ids:
         if database.unban(ban_id):
             client.send_ooc(f"Removed ban ID {ban_id}.")
             client.server.webhooks.unban(ban_id, client)
@@ -238,81 +239,70 @@ def ooc_cmd_unban(client, arg):
 
 
 @mod_only()
-def ooc_cmd_mute(client, arg):
+@command(Arg("ipids", variadic=True, type=int, help="one or more IPIDs"))
+def ooc_cmd_mute(client, ipids):
     """
     Prevent a user from speaking in-character.
     Usage: /mute <ipid>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target. Use /mute <ipid>.")
-    args = list(arg.split(" "))
-    client.send_ooc(f"Attempting to mute {len(args)} IPIDs.")
-    for raw_ipid in args:
-        if raw_ipid.isdigit():
-            ipid = int(raw_ipid)
-            clients = client.server.client_manager.get_targets(
-                client, TargetType.IPID, ipid, False
-            )
-            if clients:
-                msg = "Muted the IPID " + str(ipid) + "'s following clients:"
-                for c in clients:
-                    c.is_muted = True
-                    database.log_misc("mute", client, target=c)
-                    msg += " " + c.showname + " [" + str(c.id) + "],"
-                msg = msg[:-1]
-                msg += "."
-                client.send_ooc(msg)
-            else:
-                client.send_ooc(
-                    "No targets found. Use /mute <ipid> <ipid> ... for mute."
-                )
+    client.send_ooc(f"Attempting to mute {len(ipids)} IPIDs.")
+    for ipid in ipids:
+        clients = client.server.client_manager.get_targets(
+            client, TargetType.IPID, ipid, False
+        )
+        if clients:
+            msg = "Muted the IPID " + str(ipid) + "'s following clients:"
+            for c in clients:
+                c.is_muted = True
+                database.log_misc("mute", client, target=c)
+                msg += " " + c.showname + " [" + str(c.id) + "],"
+            msg = msg[:-1]
+            msg += "."
+            client.send_ooc(msg)
         else:
-            client.send_ooc(f"{raw_ipid} does not look like a valid IPID.")
+            client.send_ooc(
+                "No targets found. Use /mute <ipid> <ipid> ... for mute."
+            )
 
 
 @mod_only()
-def ooc_cmd_unmute(client, arg):
+@command(Arg("ipids", variadic=True, type=int, help="one or more IPIDs"))
+def ooc_cmd_unmute(client, ipids):
     """
     Unmute a user.
     Usage: /unmute <ipid>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target.")
-    args = list(arg.split(" "))
-    client.send_ooc(f"Attempting to unmute {len(args)} IPIDs.")
-    for raw_ipid in args:
-        if raw_ipid.isdigit():
-            ipid = int(raw_ipid)
-            clients = client.server.client_manager.get_targets(
-                client, TargetType.IPID, ipid, False
-            )
-            if clients:
-                msg = f"Unmuted the IPID ${str(ipid)}'s following clients:"
-                for c in clients:
-                    c.is_muted = False
-                    database.log_misc("unmute", client, target=c)
-                    msg += " " + c.showname + " [" + str(c.id) + "],"
-                msg = msg[:-1]
-                msg += "."
-                client.send_ooc(msg)
-            else:
-                client.send_ooc(
-                    "No targets found. Use /unmute <ipid> <ipid> ... for unmute."
-                )
+    client.send_ooc(f"Attempting to unmute {len(ipids)} IPIDs.")
+    for ipid in ipids:
+        clients = client.server.client_manager.get_targets(
+            client, TargetType.IPID, ipid, False
+        )
+        if clients:
+            msg = f"Unmuted the IPID {ipid}'s following clients:"
+            for c in clients:
+                c.is_muted = False
+                database.log_misc("unmute", client, target=c)
+                msg += " " + c.showname + " [" + str(c.id) + "],"
+            msg = msg[:-1]
+            msg += "."
+            client.send_ooc(msg)
         else:
-            client.send_ooc(f"{raw_ipid} does not look like a valid IPID.")
+            client.send_ooc(
+                "No targets found. Use /unmute <ipid> <ipid> ... for unmute."
+            )
 
 
-def ooc_cmd_login(client, arg):
+@command(Arg("password", rest=True, default="", help="moderator password"))
+def ooc_cmd_login(client, password):
     """
     Login as a moderator.
     Usage: /login <password>
     """
-    if len(arg) == 0:
+    if not password:
         raise ArgumentError("You must specify the password.")
     login_name = None
     try:
-        login_name = client.auth_mod(arg)
+        login_name = client.auth_mod(password)
     except ClientError:
         database.log_misc("login.invalid", client)
         raise
@@ -327,24 +317,23 @@ def ooc_cmd_login(client, arg):
 
 
 @mod_only()
-def ooc_cmd_refresh(client, arg):
+@command()
+def ooc_cmd_refresh(client):
     """
     Reload all moderator credentials, server options, and commands without
     restarting the server.
     Usage: /refresh
     """
-    if len(arg) > 0:
-        raise ClientError("This command does not take in any arguments!")
-    else:
-        try:
-            client.server.refresh()
-            database.log_misc("refresh", client)
-            client.send_ooc("You have reloaded the server.")
-        except ServerError:
-            raise
+    try:
+        client.server.refresh()
+        database.log_misc("refresh", client)
+        client.send_ooc("You have reloaded the server.")
+    except ServerError:
+        raise
 
 
-def ooc_cmd_online(client, _):
+@command()
+def ooc_cmd_online(client):
     """
     Show the number of players online.
     Usage: /online
@@ -352,7 +341,8 @@ def ooc_cmd_online(client, _):
     client.send_player_count()
 
 
-def ooc_cmd_mods(client, arg):
+@command()
+def ooc_cmd_mods(client):
     """
     Show a list of moderators online.
     Usage: /mods
@@ -360,7 +350,8 @@ def ooc_cmd_mods(client, arg):
     client.send_areas_clients(mods=True)
 
 
-def ooc_cmd_unmod(client, arg):
+@command()
+def ooc_cmd_unmod(client):
     """
     Log out as a moderator.
     Usage: /unmod
@@ -407,45 +398,48 @@ def _get_ooc_mute_targets(client, arg):
 
 
 @mod_only()
-def ooc_cmd_ooc_mute(client, arg):
+@command(Arg("target", rest=True, default="", help="ooc-name or client-id"))
+def ooc_cmd_ooc_mute(client, target):
     """
     Prevent a user from talking out-of-character.
     Usage: /ooc_mute <ooc-name|client-id>
     """
-    if len(arg) == 0:
+    if not target:
         raise ArgumentError(
             "You must specify a target. Use /ooc_mute <OOC-name>.")
-    targets = _get_ooc_mute_targets(client, arg)
+    targets = _get_ooc_mute_targets(client, target)
     if not targets:
         raise ArgumentError("Targets not found. Use /ooc_mute <OOC-name>.")
-    for target in targets:
-        target.is_ooc_muted = True
-        database.log_area("ooc_mute", client, client.area, target=target)
+    for t in targets:
+        t.is_ooc_muted = True
+        database.log_area("ooc_mute", client, client.area, target=t)
     client.send_ooc("Muted {} existing client(s).".format(len(targets)))
 
 
 @mod_only()
-def ooc_cmd_ooc_unmute(client, arg):
+@command(Arg("target", rest=True, default="", help="ooc-name or client-id"))
+def ooc_cmd_ooc_unmute(client, target):
     """
     Allow an OOC-muted user to talk out-of-character.
     Usage: /ooc_unmute <ooc-name|client-id>
     """
-    if len(arg) == 0:
+    if not target:
         raise ArgumentError(
             "You must specify a target. Use /ooc_unmute <OOC-name>.")
     targets = [
-        c for c in _get_ooc_mute_targets(client, arg) if c.is_ooc_muted
+        c for c in _get_ooc_mute_targets(client, target) if c.is_ooc_muted
     ]
     if not targets:
         raise ArgumentError("Targets not found. Use /ooc_unmute <OOC-name>.")
-    for target in targets:
-        target.is_ooc_muted = False
-        database.log_area("ooc_unmute", client, client.area, target=target)
+    for t in targets:
+        t.is_ooc_muted = False
+        database.log_area("ooc_unmute", client, client.area, target=t)
     client.send_ooc("Unmuted {} existing client(s).".format(len(targets)))
 
 
 @mod_only()
-def ooc_cmd_bans(client, _arg):
+@command()
+def ooc_cmd_bans(client):
     """
     Get the 5 most recent bans.
     Usage: /bans
@@ -461,24 +455,22 @@ def ooc_cmd_bans(client, _arg):
 
 
 @mod_only()
-def ooc_cmd_baninfo(client, arg):
+@command(
+    Arg("identifier", help="ban id, ipid, or hdid"),
+    Arg(
+        "lookup_type",
+        default="ban_id",
+        choices=("ban_id", "ipid", "hdid"),
+        help="what the id identifies",
+    ),
+)
+def ooc_cmd_baninfo(client, identifier, lookup_type):
     """
     Get information about a ban.
     Usage: /baninfo <id> ['ban_id'|'ipid'|'hdid']
     By default, id identifies a ban_id.
     """
-    args = arg.split(" ")
-    if len(arg) == 0:
-        raise ArgumentError("You must specify an ID.")
-    elif len(args) == 1:
-        lookup_type = "ban_id"
-    else:
-        lookup_type = args[1]
-
-    if lookup_type not in ("ban_id", "ipid", "hdid"):
-        raise ArgumentError("Incorrect lookup type.")
-
-    ban = database.find_ban(**{lookup_type: args[0]})
+    ban = database.find_ban(**{lookup_type: identifier})
     if ban is None:
         client.send_ooc("No ban found for this ID.")
     else:
@@ -499,13 +491,12 @@ def ooc_cmd_baninfo(client, arg):
         client.send_ooc(msg)
 
 
-def ooc_cmd_time(client, arg):
+@command()
+def ooc_cmd_time(client):
     """
     Returns the current server time.
     Usage:  /time
     """
-    if len(arg) > 0:
-        raise ArgumentError("This command takes no arguments")
     from time import asctime, gmtime, time
 
     msg = "The current time in UTC (aka GMT) is:\n["
@@ -515,7 +506,10 @@ def ooc_cmd_time(client, arg):
 
 
 @mod_only()
-def ooc_cmd_whois(client, arg):
+@command(
+    Arg("query", rest=True, default="", help="name, id, ipid, showname, or character")
+)
+def ooc_cmd_whois(client, query):
     """
     Get information about an online user.
     Usage: /whois <name|id|ipid|showname|character>
@@ -523,15 +517,15 @@ def ooc_cmd_whois(client, arg):
     found_clients = set()
     for c in client.server.client_manager.clients:
         if (
-            arg.lower() in c.name.lower()
-            or arg in c.showname.lower()
-            or arg.lower() in c.char_name.lower()
-            or arg in str(c.id)
-            or arg in str(c.ipid)
+            query.lower() in c.name.lower()
+            or query in c.showname.lower()
+            or query.lower() in c.char_name.lower()
+            or query in str(c.id)
+            or query in str(c.ipid)
         ):
             found_clients.add(c)
 
-    info = f"WHOIS lookup for {arg}:"
+    info = f"WHOIS lookup for {query}:"
     for c in found_clients:
         info += f"\n[{c.id}] "
         if c.showname != c.char_name:
@@ -546,12 +540,13 @@ def ooc_cmd_whois(client, arg):
 
 
 @mod_only()
-def ooc_cmd_restart(client, arg):
+@command(Arg("password", rest=True, default="", help="restart password"))
+def ooc_cmd_restart(client, password):
     """
     Restart the server (WARNING: The server will be *stopped* unless you set up a restart batch/bash file!)
     Usage: /restart
     """
-    if arg != client.server.config["restartpass"]:
+    if password != client.server.config["restartpass"]:
         raise ArgumentError("no")
     print(f"!!!{client.name} called /restart!!!")
     client.server.send_all_cmd_pred(
@@ -559,13 +554,12 @@ def ooc_cmd_restart(client, arg):
     asyncio.get_running_loop().stop()
 
 
-def ooc_cmd_myid(client, arg):
+@command()
+def ooc_cmd_myid(client):
     """
     Get information for your current client, such as client ID.
     Usage: /myid
     """
-    if len(arg) > 0:
-        raise ArgumentError("This command takes no arguments")
     info = f"You are: [{client.id}] "
     if client.showname != client.char_name:
         info += f'"{client.showname}" ({client.char_name})'
@@ -579,18 +573,21 @@ def ooc_cmd_myid(client, arg):
 
 
 @mod_only()
-def ooc_cmd_multiclients(client, arg):
+@command(Arg("ipid", type=int, help="IPID to look up"))
+def ooc_cmd_multiclients(client, ipid):
     """
     Get all the multi-clients of the IPID provided, detects multiclients on the same hardware even if the IPIDs are different.
     Usage: /multiclients <ipid>
     """
     found_clients = set()
     for c in client.server.client_manager.clients:
-        if arg == str(c.ipid):
+        if ipid == c.ipid:
             found_clients.add(c)
-            found_clients |= set(client.server.client_manager.get_multiclients(c.ipid, c.hdid))
+            found_clients |= set(
+                client.server.client_manager.get_multiclients(c.ipid, c.hdid)
+            )
 
-    info = f"Clients belonging to {arg}:"
+    info = f"Clients belonging to {ipid}:"
     for c in found_clients:
         info += f"\n[{c.id}] "
         if c.showname != c.char_name:

--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -127,68 +127,35 @@ def ooc_cmd_kick(client, target, reason):
         client.send_ooc(f"No targets with the IPID {ipid} were found.")
 
 
-@mod_only()
-@command(
-    Arg("args", rest=True, default="", help="<ipid> <reason>/<ban_id> [duration]")
-)
-def ooc_cmd_ban(client, args):
-    """
-    Ban a user. If a ban ID is specified instead of a reason,
-    then the IPID is added to an existing ban record.
-    Ban durations are 6 hours by default.
-    Usage: /ban <ipid> "reason" ["<N> <minute|hour|day|week|month>(s)|perma"]
-    Usage 2: /ban <ipid> <ban_id>
-    """
-    kickban(client, args, False)
+def _parse_ban_rest(rest_str):
+    """Parse the <reason|ban_id> [duration] portion of a ban command.
 
-
-@mod_only()
-@command(
-    Arg("args", rest=True, default="", help="<ipid> <reason>/<ban_id> [duration]")
-)
-def ooc_cmd_banhdid(client, args):
+    Returns ``(reason_text, ban_id, unban_date)`` where exactly one of
+    *reason_text* / *ban_id* is set.
     """
-    Ban both a user's HDID and IPID.
-    Usage: See /ban.
-    """
-    kickban(client, args, True)
-
-
-def kickban(client, arg, ban_hdid):
-    """Shared implementation of /ban and /banhdid."""
-    args = shlex.split(arg)
-    if len(args) < 2:
+    args = shlex.split(rest_str) if rest_str.strip() else []
+    if len(args) == 0:
         raise ArgumentError("Not enough arguments.")
-    elif len(args) == 2:
-        reason = None
-        ban_id = None
+    elif len(args) == 1:
         try:
-            ban_id = int(args[1])
-            unban_date = None
+            return None, int(args[0]), None
         except ValueError:
-            reason = args[1]
-            unban_date = arrow.get().shift(hours=6).datetime
-    elif len(args) == 3:
-        ban_id = None
-        reason = args[1]
-        if "perma" in args[2]:
-            unban_date = None
-        else:
-            duration = pytimeparse.parse(args[2], granularity="hours")
-            if duration is None:
-                raise ArgumentError("Invalid ban duration.")
-            unban_date = arrow.get().shift(seconds=duration).datetime
+            return args[0], None, arrow.get().shift(hours=6).datetime
+    elif len(args) == 2:
+        if "perma" in args[1]:
+            return args[0], None, None
+        duration = pytimeparse.parse(args[1], granularity="hours")
+        if duration is None:
+            raise ArgumentError("Invalid ban duration.")
+        return args[0], None, arrow.get().shift(seconds=duration).datetime
     else:
         raise ArgumentError(
-            f"Ambiguous input: {arg}\nPlease wrap your arguments " "in quotes."
+            f"Ambiguous input: {rest_str}\nPlease wrap your arguments in quotes."
         )
 
-    try:
-        raw_ipid = args[0]
-        ipid = int(raw_ipid)
-    except ValueError:
-        raise ClientError(f"{raw_ipid} does not look like a valid IPID.")
 
+def _do_ban(client, ipid, reason, ban_id, unban_date, ban_hdid=False):
+    """Execute the ban after arguments have been parsed."""
     ban_id = database.ban(
         ipid,
         reason,
@@ -200,25 +167,55 @@ def kickban(client, arg, ban_hdid):
 
     char = None
     hdid = None
-    if ipid is not None:
-        targets = client.server.client_manager.get_targets(
-            client, TargetType.IPID, ipid, False
-        )
-        if targets:
-            for c in targets:
-                if ban_hdid:
-                    database.ban(c.hdid, reason,
-                                 ban_type="hdid", ban_id=ban_id)
-                    hdid = c.hdid
-                c.send_command("KB", reason)
-                c.disconnect()
-                char = c.char_name
-                database.log_misc("ban", client, target=c,
-                                  data={"reason": reason})
-            client.send_ooc(f"{len(targets)} clients were kicked.")
-        client.send_ooc(f"{ipid} was banned. Ban ID: {ban_id}")
+    targets = client.server.client_manager.get_targets(
+        client, TargetType.IPID, ipid, False
+    )
+    if targets:
+        for c in targets:
+            if ban_hdid:
+                database.ban(c.hdid, reason,
+                             ban_type="hdid", ban_id=ban_id)
+                hdid = c.hdid
+            c.send_command("KB", reason)
+            c.disconnect()
+            char = c.char_name
+            database.log_misc("ban", client, target=c,
+                              data={"reason": reason})
+        client.send_ooc(f"{len(targets)} clients were kicked.")
+    client.send_ooc(f"{ipid} was banned. Ban ID: {ban_id}")
     client.server.webhooks.ban(
         ipid, ban_id, reason, client, hdid, char, unban_date)
+
+
+@mod_only()
+@command(
+    Arg("ipid", type=int, help="IPID to ban"),
+    Arg("reason", rest=True, default="", help="<reason> [<duration>] or <ban_id>"),
+)
+def ooc_cmd_ban(client, ipid, reason):
+    """
+    Ban a user. If a ban ID is specified instead of a reason,
+    then the IPID is added to an existing ban record.
+    Ban durations are 6 hours by default.
+    Usage: /ban <ipid> "reason" ["<N> <minute|hour|day|week|month>(s)|perma"]
+    Usage 2: /ban <ipid> <ban_id>
+    """
+    reason_text, ban_id, unban_date = _parse_ban_rest(reason)
+    _do_ban(client, ipid, reason_text, ban_id, unban_date)
+
+
+@mod_only()
+@command(
+    Arg("ipid", type=int, help="IPID to ban"),
+    Arg("reason", rest=True, default="", help="<reason> [<duration>] or <ban_id>"),
+)
+def ooc_cmd_banhdid(client, ipid, reason):
+    """
+    Ban both a user's HDID and IPID.
+    Usage: See /ban.
+    """
+    reason_text, ban_id, unban_date = _parse_ban_rest(reason)
+    _do_ban(client, ipid, reason_text, ban_id, unban_date, ban_hdid=True)
 
 
 @mod_only()

--- a/server/commands/area_access.py
+++ b/server/commands/area_access.py
@@ -1,7 +1,5 @@
 from server.exceptions import ClientError, ArgumentError, AreaError
-from . import mod_only
-
-import shlex
+from . import mod_only, command, Arg, tokens_str
 
 __all__ = [
     "ooc_cmd_area_lock",
@@ -31,17 +29,17 @@ __all__ = [
 ]
 
 
-def ooc_cmd_area_lock(client, arg):
+@command(Arg("areas", variadic=True, default=None, help="area IDs (blank = current)"))
+def ooc_cmd_area_lock(client, areas):
     """
     Prevent users from joining the current area.
     Usage: /area_lock
     """
-    args = shlex.split(arg)
-    if len(args) == 0:
-        args = [str(client.area.id)]
+    if not areas:
+        areas = [str(client.area.id)]
 
     try:
-        area_list = client.area.area_manager.get_areas_by_args(args)
+        area_list = client.area.area_manager.get_areas_by_args(areas)
         for area in area_list:
             if not client.is_mod and client not in area.owners:
                 if not str(area.id) in client.keys:
@@ -79,17 +77,17 @@ def ooc_cmd_area_lock(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_area_mute(client, arg):
+@command(Arg("areas", variadic=True, default=None, help="area IDs (blank = current)"))
+def ooc_cmd_area_mute(client, areas):
     """
     Makes this area impossible to speak for normal users unlesss /invite is used.
     Usage: /area_mute
     """
-    args = shlex.split(arg)
-    if len(args) == 0:
-        args = [str(client.area.id)]
+    if not areas:
+        areas = [str(client.area.id)]
 
     try:
-        area_list = client.area.area_manager.get_areas_by_args(args)
+        area_list = client.area.area_manager.get_areas_by_args(areas)
         for area in area_list:
             if not client.is_mod and client not in area.owners:
                 client.send_ooc(f"You don't own area [{area.id}] {area.name}.")
@@ -110,17 +108,17 @@ def ooc_cmd_area_mute(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_area_unmute(client, arg):
+@command(Arg("areas", variadic=True, default=None, help="area IDs (blank = current)"))
+def ooc_cmd_area_unmute(client, areas):
     """
     Undo the effects of /area_mute.
     Usage: /area_unmute
     """
-    args = shlex.split(arg)
-    if len(args) == 0:
-        args = [str(client.area.id)]
+    if not areas:
+        areas = [str(client.area.id)]
 
     try:
-        area_list = client.area.area_manager.get_areas_by_args(args)
+        area_list = client.area.area_manager.get_areas_by_args(areas)
         for area in area_list:
             if not client.is_mod and client not in area.owners:
                 client.send_ooc(f"You don't own area [{area.id}] {area.name}.")
@@ -140,17 +138,17 @@ def ooc_cmd_area_unmute(client, arg):
         raise
 
 
-def ooc_cmd_area_unlock(client, arg):
+@command(Arg("areas", variadic=True, default=None, help="area IDs (blank = current)"))
+def ooc_cmd_area_unlock(client, areas):
     """
     Allow anyone to freely join the current area.
     Usage: /area_unlock
     """
-    args = shlex.split(arg)
-    if len(args) == 0:
-        args = [str(client.area.id)]
+    if not areas:
+        areas = [str(client.area.id)]
 
     try:
-        area_list = client.area.area_manager.get_areas_by_args(args)
+        area_list = client.area.area_manager.get_areas_by_args(areas)
         for area in area_list:
             if not client.is_mod and client not in area.owners:
                 if not str(area.id) in client.keys:
@@ -187,15 +185,16 @@ def ooc_cmd_area_unlock(client, arg):
         raise
 
 
-def ooc_cmd_lock(client, arg):
+@command(Arg("targets", rest=True, type=tokens_str, default="", help="area IDs and/or !link IDs"))
+def ooc_cmd_lock(client, targets):
     """
     Context-sensitive function to lock area(s) and/or area link(s).
     Usage: /lock - lock current area. /lock [id] - lock target area. /lock !5 - lock the link from current area to area 5.
     Multiple targets may be passed.
     """
-    if arg == "":
-        arg = str(client.area.id)
-    args = arg.split()
+    if targets == "":
+        targets = str(client.area.id)
+    args = targets.split()
     areas = args.copy()
     links = []
     for a in args:
@@ -212,15 +211,16 @@ def ooc_cmd_lock(client, arg):
         ooc_cmd_link_lock(client, links)
 
 
-def ooc_cmd_unlock(client, arg):
+@command(Arg("targets", rest=True, type=tokens_str, default="", help="area IDs and/or !link IDs"))
+def ooc_cmd_unlock(client, targets):
     """
     Context-sensitive function to unlock area(s) and/or area link(s).
     Usage: /unlock - unlock current area. /unlock [id] - unlock target area. /unlock !5 - unlock the link from current area to area 5.
     Multiple targets may be passed.
     """
-    if arg == "":
-        arg = str(client.area.id)
-    args = arg.split()
+    if targets == "":
+        targets = str(client.area.id)
+    args = targets.split()
     areas = args.copy()
     links = []
     for a in args:
@@ -237,18 +237,18 @@ def ooc_cmd_unlock(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_link(client, arg):
+@command(Arg("areas", variadic=True, default=None, help="area IDs (blank shows links)"))
+def ooc_cmd_link(client, areas):
     """
     Set up a two-way link from your current area with targeted area(s).
     Usage:  /link <id(s)>
     """
-    args = arg.split()
-    if len(args) <= 0:
-        ooc_cmd_links(client, arg)
+    if not areas:
+        ooc_cmd_links(client, "")
         return
     try:
         links = []
-        for aid in args:
+        for aid in areas:
             try:
                 area = client.area.area_manager.get_area_by_abbreviation(aid)
                 target_id = area.id
@@ -277,17 +277,15 @@ def ooc_cmd_link(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_unlink(client, arg):
+@command(Arg("areas", variadic=True, help="area IDs"))
+def ooc_cmd_unlink(client, areas):
     """
     Remove a two-way link from your current area with targeted area(s).
     Usage:  /unlink <id(s)>
     """
-    args = arg.split()
-    if len(args) <= 0:
-        raise ArgumentError("Invalid number of arguments. Use /unlink <aid>")
     try:
         links = []
-        for aid in args:
+        for aid in areas:
             try:
                 area = client.area.area_manager.get_area_by_abbreviation(aid)
                 target_id = area.id
@@ -318,7 +316,8 @@ def ooc_cmd_unlink(client, arg):
         raise
 
 
-def ooc_cmd_links(client, arg):
+@command()
+def ooc_cmd_links(client):
     """
     Display this area's information about area links.
     Usage:  /links
@@ -363,18 +362,18 @@ def ooc_cmd_links(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_onelink(client, arg):
+@command(Arg("areas", variadic=True, default=None, help="area IDs (blank shows links)"))
+def ooc_cmd_onelink(client, areas):
     """
     Set up a one-way link from your current area with targeted area(s).
     Usage:  /onelink <id(s)>
     """
-    args = arg.split()
-    if len(args) <= 0:
-        ooc_cmd_links(client, arg)
+    if not areas:
+        ooc_cmd_links(client, "")
         return
     try:
         links = []
-        for aid in args:
+        for aid in areas:
             try:
                 area = client.area.area_manager.get_area_by_abbreviation(aid)
                 target_id = area.id
@@ -400,18 +399,15 @@ def ooc_cmd_onelink(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_oneunlink(client, arg):
+@command(Arg("areas", variadic=True, help="area IDs"))
+def ooc_cmd_oneunlink(client, areas):
     """
     Remove a one-way link from your current area with targeted area(s).
     Usage:  /oneunlink <id(s)>
     """
-    args = arg.split()
-    if len(args) <= 0:
-        raise ArgumentError(
-            "Invalid number of arguments. Use /oneunlink <aid>")
     try:
         links = []
-        for aid in args:
+        for aid in areas:
             try:
                 target_id = client.area.area_manager.get_area_by_abbreviation(
                     aid).id
@@ -434,18 +430,15 @@ def ooc_cmd_oneunlink(client, arg):
         raise
 
 
-def ooc_cmd_link_lock(client, arg):
+@command(Arg("areas", variadic=True, help="area IDs"))
+def ooc_cmd_link_lock(client, areas):
     """
     Lock the path leading to target area(s).
     Usage:  /link_lock <id(s)>
     """
-    args = arg.split()
-    if len(args) <= 0:
-        raise ArgumentError(
-            "Invalid number of arguments. Use /link_lock <aid>")
     try:
         links = []
-        for aid in args:
+        for aid in areas:
             try:
                 target_id = client.area.area_manager.get_area_by_abbreviation(
                     aid).id
@@ -479,18 +472,15 @@ def ooc_cmd_link_lock(client, arg):
         raise
 
 
-def ooc_cmd_link_unlock(client, arg):
+@command(Arg("areas", variadic=True, help="area IDs"))
+def ooc_cmd_link_unlock(client, areas):
     """
     Unlock the path leading to target area(s).
     Usage:  /link_unlock <id(s)>
     """
-    args = arg.split()
-    if len(args) <= 0:
-        raise ArgumentError(
-            "Invalid number of arguments. Use /link_unlock <aid>")
     try:
         links = []
-        for aid in args:
+        for aid in areas:
             try:
                 target_id = client.area.area_manager.get_area_by_abbreviation(
                     aid).id
@@ -525,18 +515,15 @@ def ooc_cmd_link_unlock(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_link_hide(client, arg):
+@command(Arg("areas", variadic=True, help="area IDs"))
+def ooc_cmd_link_hide(client, areas):
     """
     Hide the path leading to target area(s).
     Usage:  /link_hide <id(s)>
     """
-    args = arg.split()
-    if len(args) <= 0:
-        raise ArgumentError(
-            "Invalid number of arguments. Use /link_hide <aid>")
     try:
         links = []
-        for aid in args:
+        for aid in areas:
             try:
                 target_id = client.area.area_manager.get_area_by_abbreviation(
                     aid).id
@@ -555,18 +542,15 @@ def ooc_cmd_link_hide(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_link_unhide(client, arg):
+@command(Arg("areas", variadic=True, help="area IDs"))
+def ooc_cmd_link_unhide(client, areas):
     """
     Unhide the path leading to target area(s).
     Usage:  /link_unhide <id(s)>
     """
-    args = arg.split()
-    if len(args) <= 0:
-        raise ArgumentError(
-            "Invalid number of arguments. Use /link_unhide <aid>")
     try:
         links = []
-        for aid in args:
+        for aid in areas:
             try:
                 target_id = client.area.area_manager.get_area_by_abbreviation(
                     aid).id
@@ -585,23 +569,22 @@ def ooc_cmd_link_unhide(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_link_pos(client, arg):
+@command(
+    Arg("id", help="area ID or abbreviation"),
+    Arg("pos", rest=True, type=tokens_str, default="", help="target pos (blank resets)"),
+)
+def ooc_cmd_link_pos(client, id, pos):
     """
     Set the link's targeted pos when using it. Leave blank to reset.
     Usage:  /link_pos <id> [pos]
     """
-    args = arg.split()
-    if len(args) <= 0:
-        raise ArgumentError(
-            "Invalid number of arguments. Use /link_unhide <aid>")
     try:
         try:
             target_id = client.area.area_manager.get_area_by_abbreviation(
-                args[0]).id
+                id).id
         except Exception:
-            target_id = int(args[0])
+            target_id = int(id)
 
-        pos = ' '.join(args[1:])
         client.area.links[str(target_id)]["target_pos"] = pos
         client.send_ooc(
             f'Area {client.area.name} link {target_id}\'s target pos set to "{pos}".'
@@ -613,18 +596,15 @@ def ooc_cmd_link_pos(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_link_peekable(client, arg):
+@command(Arg("areas", variadic=True, help="area IDs"))
+def ooc_cmd_link_peekable(client, areas):
     """
     Make the path(s) leading to target area(s) /peek-able.
     Usage:  /link_peekable <id(s)>
     """
-    args = arg.split()
-    if len(args) <= 0:
-        raise ArgumentError(
-            "Invalid number of arguments. Use /link_peekable <aid>")
     try:
         links = []
-        for aid in args:
+        for aid in areas:
             try:
                 target_id = client.area.area_manager.get_area_by_abbreviation(
                     aid).id
@@ -644,18 +624,15 @@ def ooc_cmd_link_peekable(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_link_unpeekable(client, arg):
+@command(Arg("areas", variadic=True, help="area IDs"))
+def ooc_cmd_link_unpeekable(client, areas):
     """
     Make the path(s) leading to target area(s) no longer /peek-able.
     Usage:  /link_unpeekable <id(s)>
     """
-    args = arg.split()
-    if len(args) <= 0:
-        raise ArgumentError(
-            "Invalid number of arguments. Use /link_unpeekable <aid>")
     try:
         links = []
-        for aid in args:
+        for aid in areas:
             try:
                 target_id = client.area.area_manager.get_area_by_abbreviation(
                     aid).id
@@ -676,18 +653,16 @@ def ooc_cmd_link_unpeekable(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_link_seethrough(client, arg):
+@command(Arg("areas", variadic=True, help="area IDs"))
+def ooc_cmd_link_seethrough(client, areas):
     """
     Make the path(s) leading to target area(s) see-through. Clients in this
     area automatically see the target's presence and passing messages.
     Usage:  /link_seethrough <id(s)>
     """
-    args = arg.split()
-    if len(args) <= 0:
-        raise ArgumentError("Invalid number of arguments. Use /link_seethrough <aid>")
     try:
         links = []
-        for aid in args:
+        for aid in areas:
             try:
                 target_id = client.area.area_manager.get_area_by_abbreviation(
                     aid).id
@@ -707,17 +682,15 @@ def ooc_cmd_link_seethrough(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_link_unseethrough(client, arg):
+@command(Arg("areas", variadic=True, help="area IDs"))
+def ooc_cmd_link_unseethrough(client, areas):
     """
     Make the path(s) leading to target area(s) no longer see-through.
     Usage:  /link_unseethrough <id(s)>
     """
-    args = arg.split()
-    if len(args) <= 0:
-        raise ArgumentError("Invalid number of arguments. Use /link_unseethrough <aid>")
     try:
         links = []
-        for aid in args:
+        for aid in areas:
             try:
                 target_id = client.area.area_manager.get_area_by_abbreviation(
                     aid).id
@@ -738,28 +711,24 @@ def ooc_cmd_link_unseethrough(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_link_evidence(client, arg):
+@command(
+    Arg("id", help="area ID"),
+    Arg("evidences", int, variadic=True, default=[], help="evidence IDs (blank shows current)"),
+)
+def ooc_cmd_link_evidence(client, id, evidences):
     """
     Make specific link only accessible from evidence ID(s).
     Pass evidence ID's which you can see by mousing over evidence, or blank to see current evidences.
     Usage:  /link_evidence <id> [evi_id(s)]
     """
-    args = arg.split()
-    if len(args) <= 0:
-        raise ArgumentError(
-            "Invalid number of arguments. Use /link_evidence <id> [evi_id(s)]"
-        )
     link = None
-    evidences = []
+    evidences = [evi - 1 for evi in evidences]
     try:
-        link = client.area.links[args[0]]
-        if len(args) > 1:
-            for evi_id in args[1:]:
-                evi_id = int(evi_id) - 1
-                client.area.evi_list.evidences[
-                    evi_id
-                ]  # Test if we can access target evidence
-                evidences.append(evi_id)
+        link = client.area.links[id]
+        for evi_id in evidences:
+            client.area.evi_list.evidences[
+                evi_id
+            ]  # Test if we can access target evidence
     except IndexError:
         raise ArgumentError("Evidence not found.")
     except (ValueError, KeyError):
@@ -773,34 +742,29 @@ def ooc_cmd_link_evidence(client, arg):
         if len(link["evidence"]) > 0:
             evi_list = ", ".join(str(evi + 1) for evi in link["evidence"])
             client.send_ooc(
-                f"Area {client.area.name} link {args[0]} associated evidence IDs: {evi_list}."
+                f"Area {client.area.name} link {id} associated evidence IDs: {evi_list}."
             )
         else:
             client.send_ooc(
-                f"Area {client.area.name} link {args[0]} has no associated evidence."
+                f"Area {client.area.name} link {id} has no associated evidence."
             )
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_unlink_evidence(client, arg):
+@command(
+    Arg("id", help="area ID"),
+    Arg("evidences", int, variadic=True, default=[], help="evidence IDs (blank clears all)"),
+)
+def ooc_cmd_unlink_evidence(client, id, evidences):
     """
     Unlink evidence from links.
     Pass evidence ID's which you can see by mousing over evidence.
     Usage:  /unlink_evidence <aid> [evi_id(s)]
     """
-    args = arg.split()
-    if len(args) <= 0:
-        raise ArgumentError(
-            "Invalid number of arguments. Use /unlink_evidence <aid> [evi_id(s)]"
-        )
     link = None
-    evidences = []
+    evidences = [evi - 1 for evi in evidences]
     try:
-        link = client.area.links[args[0]]
-        if len(args) > 1:
-            for evi_id in args[1:]:
-                evi_id = int(evi_id) - 1
-                evidences.append(evi_id)
+        link = client.area.links[id]
     except (ValueError, KeyError):
         raise ArgumentError("Area ID must be a number.")
     except (AreaError, ClientError):
@@ -810,15 +774,16 @@ def ooc_cmd_unlink_evidence(client, arg):
             link["evidence"] = link["evidence"] - evidences
             evi_list = ", ".join(str(evi + 1) for evi in evidences)
             client.send_ooc(
-                f"Area {client.area.name} link {args[0]} is now unlinked from evidence IDs: {evi_list}."
+                f"Area {client.area.name} link {id} is now unlinked from evidence IDs: {evi_list}."
             )
         else:
             link["evidence"] = []
             client.send_ooc(
-                f"Area {client.area.name} link {args[0]} associated evidences cleared."
+                f"Area {client.area.name} link {id} associated evidences cleared."
             )
 
 
+@command(Arg("arg", rest=True, default="", help="<id> [password]"))
 def ooc_cmd_pw(client, arg):
     """
     Enter a passworded area. Password is case-sensitive and must match the set password exactly, otherwise it will fail.
@@ -867,6 +832,7 @@ def ooc_cmd_pw(client, arg):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="<id/!link> [password]"))
 def ooc_cmd_setpw(client, arg):
     """
     Context-sensitive function to set a password area(s) and/or area link(s).

--- a/server/commands/area_access.py
+++ b/server/commands/area_access.py
@@ -783,8 +783,11 @@ def ooc_cmd_unlink_evidence(client, id, evidences):
             )
 
 
-@command(Arg("arg", rest=True, default="", help="<id> [password]"))
-def ooc_cmd_pw(client, arg):
+@command(
+    Arg("area_id", type=int, default=None, help="area id"),
+    Arg("password", rest=True, default="", help="password"),
+)
+def ooc_cmd_pw(client, area_id, password):
     """
     Enter a passworded area. Password is case-sensitive and must match the set password exactly, otherwise it will fail.
     You will move into the target area as soon as the correct password is provided.
@@ -792,20 +795,16 @@ def ooc_cmd_pw(client, arg):
     Usage:  /pw <id> [password]
     """
     link = None
-    password = ""
-    if arg == "":
+    if area_id is None:
         if not client.is_mod and not (client in client.area.owners):
             raise ArgumentError(
                 "You are not allowed to see this area's password. Use /pw <id> [password]"
             )
         aid = client.area.id
     else:
-        args = arg.split()
-        aid = args[0]
+        aid = str(area_id)
         if aid in client.area.links:
             link = client.area.links[aid]
-        if len(args) > 1:
-            password = args[1]
 
     try:
         area = client.area.area_manager.get_area_by_id(int(aid))
@@ -825,32 +824,27 @@ def ooc_cmd_pw(client, arg):
                 )
         else:
             client.change_area(area, password=password)
-    except ValueError:
-        raise ArgumentError("Area ID must be a number.")
     except (AreaError, ClientError):
         raise
 
 
 @mod_only(area_owners=True)
-@command(Arg("arg", rest=True, default="", help="<id/!link> [password]"))
-def ooc_cmd_setpw(client, arg):
+@command(
+    Arg("target", help="area id or !link id"),
+    Arg("password", rest=True, default="", help="password"),
+)
+def ooc_cmd_setpw(client, target, password):
     """
     Context-sensitive function to set a password area(s) and/or area link(s).
     Pass area id, or link id from current area using !, e.g. 5 vs !5.
     Leave [password] blank to clear the password.
     Usage:  /setpw <id> [password]
     """
-    args = arg.split()
-    if len(args) == 0:
-        raise ArgumentError(
-            "Invalid number of arguments. Use /setpw <id> [password]")
-
     try:
-        password = ""
         link = None
         area = client.area
-        if args[0].startswith("!"):
-            num = args[0][1:]
+        if target.startswith("!"):
+            num = target[1:]
             if num in client.area.links:
                 link = client.area.links[num]
                 area = client.area.area_manager.get_area_by_id(int(num))
@@ -858,9 +852,7 @@ def ooc_cmd_setpw(client, arg):
                 raise ArgumentError(
                     "Targeted link does not exist in current area.")
         else:
-            area = client.area.area_manager.get_area_by_id(int(args[0]))
-        if len(args) > 1:
-            password = args[1]
+            area = client.area.area_manager.get_area_by_id(int(target))
         if not client.is_mod and not (client in area.owners):
             raise ClientError("You do not own that area!")
         if link is not None:

--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -4,7 +4,7 @@ from server import database
 from server.constants import TargetType
 from server.exceptions import ClientError, ArgumentError, AreaError
 
-from . import mod_only
+from . import mod_only, command, Arg
 
 __all__ = [
     "ooc_cmd_overlay",
@@ -40,6 +40,7 @@ __all__ = [
     "ooc_cmd_clear_area_broadcast",
 ]
 
+@command(Arg("arg", rest=True, default="", help="background (blank shows current)"))
 def ooc_cmd_overlay(client, arg):
     """
     Set the overlay of an area.
@@ -72,7 +73,8 @@ def ooc_cmd_overlay(client, arg):
         f"{client.showname} changed the overlay to {arg}.")
     database.log_area("overlay", client, client.area, message=arg)
 
-def ooc_cmd_overlay_clear(client, arg):
+@command()
+def ooc_cmd_overlay_clear(client):
     """
     Clear the overlay of an area.
     Usage: /overlay_clear
@@ -99,6 +101,7 @@ def ooc_cmd_overlay_clear(client, arg):
         f"{client.showname} cleared the overlay.")
     database.log_area("overlay_clear", client, client.area)
 
+@command(Arg("arg", rest=True, default="", help="background (blank shows current)"))
 def ooc_cmd_bg(client, arg):
     """
     Set the background of an area.
@@ -137,6 +140,7 @@ def ooc_cmd_bg(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="<area_id> <background> [overlay]"))
 def ooc_cmd_gm_set_bg(client, arg):
     """
     Change the background of any area in your current hub (hub GMs only).
@@ -159,6 +163,7 @@ def ooc_cmd_gm_set_bg(client, arg):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="suffix (blank clears)"))
 def ooc_cmd_bg_suffix(client, arg):
     """
     Set the background suffix of an area, which is what will be appended at the end of the area's /bg.
@@ -175,6 +180,7 @@ def ooc_cmd_bg_suffix(client, arg):
     database.log_area("bg", client, client.area, message=arg)
 
 
+@command(Arg("arg", rest=True, default="", help="category (blank lists categories)"))
 def ooc_cmd_bgs(client, arg):
     """
     Display the server's available backgrounds.
@@ -194,6 +200,7 @@ def ooc_cmd_bgs(client, arg):
         client.send_ooc("There is no category with this name in server background list.")
 
 
+@command(Arg("arg", rest=True, default="", help="status (blank shows current)"))
 def ooc_cmd_status(client, arg):
     """
     Show or modify the current status of an area.
@@ -231,6 +238,7 @@ def ooc_cmd_status(client, arg):
             raise
 
 
+@command(Arg("arg", rest=True, default="", help="area id or name (blank lists)"))
 def ooc_cmd_area(client, arg):
     """
     Go to the specified area.
@@ -266,13 +274,12 @@ def ooc_cmd_area(client, arg):
         raise
 
 
-def ooc_cmd_area_visible(client, arg):
+@command()
+def ooc_cmd_area_visible(client):
     """
     Display only linked and non-hidden areas. Useful to GMs.
     Usage: /area_visible
     """
-    if arg != "":
-        raise ArgumentError("This command takes no arguments!")
     client.available_areas_only = not client.available_areas_only
     toggle = "enabled" if client.available_areas_only else "disabled"
     client.area.broadcast_area_list(client)
@@ -281,7 +288,8 @@ def ooc_cmd_area_visible(client, arg):
     )
 
 
-def ooc_cmd_autogetarea(client, arg):
+@command()
+def ooc_cmd_autogetarea(client):
     """
     Automatically /getarea whenever you enter a new area
     Usage: /autogetarea
@@ -293,6 +301,7 @@ def ooc_cmd_autogetarea(client, arg):
     )
 
 
+@command(Arg("arg", default="", help="area id (blank = current)"))
 def ooc_cmd_getarea(client, arg):
     """
     Show information about the current area, or target area id with sufficient permissions.
@@ -310,20 +319,23 @@ def ooc_cmd_getarea(client, arg):
     client.area.broadcast_player_list_to_target(client)
 
 
-def ooc_cmd_getareas(client, arg):
+@command()
+def ooc_cmd_getareas(client):
     """
     Show information about all areas.
     Usage: /getareas
     """
     client.send_areas_clients()
 
-def ooc_cmd_gethubs(client, arg):
+@command()
+def ooc_cmd_gethubs(client):
     """
     Show information about all hubs.
     Usage: /gethubs
     """
     client.send_hubs_clients()
 
+@command(Arg("arg", default="", help="area id (blank = current)"))
 def ooc_cmd_getlink(client, arg):
     """
     Show information about the current area, or target area id with sufficient permissions.
@@ -341,7 +353,8 @@ def ooc_cmd_getlink(client, arg):
     client.send_area_info(aid, show_links=True)
 
 
-def ooc_cmd_getlinks(client, arg):
+@command()
+def ooc_cmd_getlinks(client):
     """
     Show information about all areas.
     Including the client's link.
@@ -349,6 +362,7 @@ def ooc_cmd_getlinks(client, arg):
     """
     client.send_areas_clients(show_links=True)
 
+@command(Arg("arg", default="", help="all or blank"))
 def ooc_cmd_getafk(client, arg):
     """
     Show currently AFK-ing players in the current area or in all areas.
@@ -364,6 +378,7 @@ def ooc_cmd_getafk(client, arg):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="client ID or * (blank lists invites)"))
 def ooc_cmd_invite(client, arg):
     """
     Allow a particular user to join a locked or speak in spectator-only area.
@@ -411,6 +426,7 @@ def ooc_cmd_invite(client, arg):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="client ID or *"))
 def ooc_cmd_uninvite(client, arg):
     """
     Revoke an invitation for a particular user.
@@ -453,6 +469,7 @@ def ooc_cmd_uninvite(client, arg):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="<id> [destination] [target_pos]"))
 def ooc_cmd_area_kick(client, arg):
     """
     Remove a user from the current area and move them to another area.
@@ -569,7 +586,8 @@ def ooc_cmd_area_kick(client, arg):
 
 # TODO: actually finish this command
 @mod_only(area_owners=True)
-def ooc_cmd_shuffle_pos(client, arg):
+@command()
+def ooc_cmd_shuffle_pos(client):
     """
     Randomly shuffle the players into a list of pos separated by space or comma.
     If your pos have spaces in them, it must be a comma-separated list like /shuffle_pos pos one, pos two, pos X
@@ -579,6 +597,7 @@ def ooc_cmd_shuffle_pos(client, arg):
     client.area.broadcast_ooc("Position lock cleared.")
 
 
+@command(Arg("arg", rest=True, default="", help="pos(s) (blank shows current)"))
 def ooc_cmd_pos_lock(client, arg):
     """
     Lock current area's available positions into a list of pos separated by space or comma.
@@ -633,7 +652,8 @@ def ooc_cmd_pos_lock(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_pos_lock_clear(client, arg):
+@command()
+def ooc_cmd_pos_lock_clear(client):
     """
     Clear the current area's position lock and make all positions available.
     Usage:  /pos_lock_clear
@@ -642,6 +662,7 @@ def ooc_cmd_pos_lock_clear(client, arg):
     client.area.broadcast_ooc("Position lock cleared.")
 
 
+@command(Arg("arg", rest=True, default="", help="area name or ID"))
 def ooc_cmd_knock(client, arg):
     """
     Knock on the target area ID to call on their attention to your area.
@@ -716,6 +737,7 @@ def ooc_cmd_knock(client, arg):
         raise
 
 
+@command(Arg("arg", rest=True, default="", help="area name or ID"))
 def ooc_cmd_peek(client, arg):
     """
     Peek into an area to see if there's people in it.
@@ -805,32 +827,27 @@ def ooc_cmd_peek(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_max_players(client, arg):
+@command(Arg("num", int, default=None, help="max players (-1..99, blank shows)"))
+def ooc_cmd_max_players(client, num):
     """
     Set a max amount of players for current area between -1 and 99.
     Usage: /max_players [num]
     """
-    if arg == "":
+    if num is None:
         client.send_ooc(
             f"Max amount of players for the area is {client.area.max_players}."
         )
         return
 
-    try:
-        arg = int(arg)
-        if arg < -1 or arg > 99:
-            raise ClientError("The min-max values are -1 and 99!")
-        client.area.max_players = arg
-        client.send_ooc(
-            f"New max amount of players for the area is now {client.area.max_players}."
-        )
-    except ValueError:
-        raise ArgumentError(
-            "Area ID must be a name, abbreviation or a number.")
-    except (AreaError, ClientError):
-        raise
+    if num < -1 or num > 99:
+        raise ClientError("The min-max values are -1 and 99!")
+    client.area.max_players = num
+    client.send_ooc(
+        f"New max amount of players for the area is now {client.area.max_players}."
+    )
 
 
+@command(Arg("arg", rest=True, default="", help="description (blank shows current)"))
 def ooc_cmd_desc(client, arg):
     """
     Set an area description that appears to the user any time they enter the area.
@@ -873,7 +890,8 @@ def ooc_cmd_desc(client, arg):
         database.log_area("desc.change", client, client.area, message=arg)
 
 
-def ooc_cmd_desc_clear(client, arg):
+@command()
+def ooc_cmd_desc_clear(client):
     """
     Clears the area description that appears to the user any time they enter the area.
     Usage: /desc_clear
@@ -901,25 +919,14 @@ def ooc_cmd_desc_clear(client, arg):
     database.log_area("desc.clear", client, client.area)
 
 @mod_only(area_owners=True)
-def ooc_cmd_edit_ambience(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_edit_ambience(client, tog):
     """
     Toggle edit mode for setting ambience. Playing music will set it as the area's ambience.
     tog can be `on`, `off` or empty.
     Usage: /edit_ambience [tog]
     """
-    if len(arg.split()) > 1:
-        raise ArgumentError(
-            "This command can only take one argument ('on' or 'off') or no arguments at all!"
-        )
-    if arg:
-        if arg == "on":
-            client.edit_ambience = True
-        elif arg == "off":
-            client.edit_ambience = False
-        else:
-            raise ArgumentError("Invalid argument: {}".format(arg))
-    else:
-        client.edit_ambience = not client.edit_ambience
+    client.edit_ambience = not client.edit_ambience if tog is None else tog
     stat = "no longer"
     if client.edit_ambience:
         stat = "now"
@@ -927,7 +934,8 @@ def ooc_cmd_edit_ambience(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_lights(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_lights(client, tog):
     """
     Toggle lights for this area. If lights are off, players will not be able to use /getarea or see evidence.
     Players will also be unable to see area movement messages or use /chardesc.
@@ -935,19 +943,7 @@ def ooc_cmd_lights(client, arg):
     tog can be `on`, `off` or empty.
     Usage: /lights [tog]
     """
-    if len(arg.split()) > 1:
-        raise ArgumentError(
-            "This command can only take one argument ('on' or 'off') or no arguments at all!"
-        )
-    if arg:
-        if arg == "on":
-            client.area.dark = False
-        elif arg == "off":
-            client.area.dark = True
-        else:
-            raise ArgumentError("Invalid argument: {}".format(arg))
-    else:
-        client.area.dark = not client.area.dark
+    client.area.dark = not client.area.dark if tog is None else not tog
     stat = "no longer"
     if client.area.dark:
         stat = "now"
@@ -960,36 +956,34 @@ def ooc_cmd_lights(client, arg):
     client.area.broadcast_evidence_list()
 
 
-def ooc_cmd_auto_pair(client, arg):
+@command(Arg("mode", choices=["double", "triple"]))
+def ooc_cmd_auto_pair(client, mode):
     """
     Set the max of players displayed on the screen.
     Usage: /auto_pair <double/triple>
     """
-    if arg.lower() not in ["double", "triple"]:
-        client.send_ooc("Argument Error!\nUsage: /auto_pair <double/triple>")
-        return
-    client.area.auto_pair_max = arg.lower()
-    if arg.lower() == "triple":
+    client.area.auto_pair_max = mode
+    if mode == "triple":
         client.send_ooc("Pairing will show a maximum of 3 characters on screen now")
     else:
         client.send_ooc("Pairing will show a maximum of 2 characters on screen now")
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_area_broadcast(client, arg):
+@command(Arg("areas", variadic=True, default=None, help="area IDs (blank shows current)"))
+def ooc_cmd_area_broadcast(client, areas):
     """
     Start broadcasting current area's IC, Music and Judge buttons to specified area ID's.
     To include all areas, use /area_broadcast all
     /clear_area_broadcast to clear the list
     Usage: /area_broadcast <id(s)>
     """
-    args = shlex.split(arg)
-    if len(args) <= 0:
+    if not areas:
         a_list = ", ".join([str(a.id) for a in client.area.broadcast_list])
         client.send_ooc(f"Current area broadcast list is {a_list}")
         return
     try:
-        broadcast_list = client.area.area_manager.get_areas_by_args(args)
+        broadcast_list = client.area.area_manager.get_areas_by_args(areas)
         client.area.broadcast_list = broadcast_list
         a_list = ", ".join([str(a.id) for a in client.area.broadcast_list])
         client.send_ooc(f"Area's broadcast list is now {a_list}")
@@ -1000,7 +994,8 @@ def ooc_cmd_area_broadcast(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_clear_area_broadcast(client, arg):
+@command()
+def ooc_cmd_clear_area_broadcast(client):
     """
     Clear the area's broadcasting of IC, Music and Judge buttons.
     Usage: /clear_area_broadcast

--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -1,5 +1,3 @@
-import shlex
-
 from server import database
 from server.constants import TargetType
 from server.exceptions import ClientError, ArgumentError, AreaError
@@ -140,26 +138,24 @@ def ooc_cmd_bg(client, arg):
 
 
 @mod_only(hub_owners=True)
-@command(Arg("arg", rest=True, default="", help="<area_id> <background> [overlay]"))
-def ooc_cmd_gm_set_bg(client, arg):
+@command(
+    Arg("area_id", type=int, help="area id"),
+    Arg("background", help="background name"),
+    Arg("overlay", rest=True, default="", help="overlay (blank keeps current)"),
+)
+def ooc_cmd_gm_set_bg(client, area_id, background, overlay):
     """
     Change the background of any area in your current hub (hub GMs only).
     Usage: /gm_set_bg <area_id> <background> [overlay]
     """
-    args = arg.split(" ", 2)
-    if len(args) < 2:
-        raise ArgumentError("Usage: /gm_set_bg <area_id> <background> [overlay]")
-    try:
-        area_id = int(args[0])
-    except ValueError:
-        raise ArgumentError("area_id must be a number.")
     hub = client.area.area_manager
     if area_id < 0 or area_id >= len(hub.areas):
         raise ArgumentError("No such area in your hub.")
     target = hub.areas[area_id]
-    overlay = args[2] if len(args) > 2 else target.overlay
-    target.change_background(args[1], overlay)
-    client.send_ooc(f"Set area {area_id}'s background to {args[1]}.")
+    if not overlay:
+        overlay = target.overlay
+    target.change_background(background, overlay)
+    client.send_ooc(f"Set area {area_id}'s background to {background}.")
 
 
 @mod_only(area_owners=True)
@@ -200,15 +196,22 @@ def ooc_cmd_bgs(client, arg):
         client.send_ooc("There is no category with this name in server background list.")
 
 
-@command(Arg("arg", rest=True, default="", help="status (blank shows current)"))
-def ooc_cmd_status(client, arg):
+@command(
+    Arg(
+        "status",
+        default="",
+        choices=("idle", "rp", "casing", "looking-for-players", "lfp", "recess", "gaming"),
+        help="status (blank shows current)",
+    ),
+)
+def ooc_cmd_status(client, status):
     """
     Show or modify the current status of an area.
     Usage: /status <idle|rp|casing|looking-for-players|lfp|recess|gaming>
     """
     if not client.area.area_manager.arup_enabled:
         raise AreaError("This hub does not use the /status system.")
-    if len(arg) == 0:
+    if not status:
         client.send_ooc(f"Current status: {client.area.status}")
     else:
         if (
@@ -228,12 +231,12 @@ def ooc_cmd_status(client, arg):
         ):
             raise ClientError("You may not do that while spectating!")
         try:
-            client.area.change_status(arg)
+            client.area.change_status(status)
             client.area.broadcast_ooc(
                 "{} changed status to {}.".format(
                     client.showname, client.area.status)
             )
-            database.log_area("status", client, client.area, message=arg)
+            database.log_area("status", client, client.area, message=status)
         except AreaError:
             raise
 
@@ -301,17 +304,17 @@ def ooc_cmd_autogetarea(client):
     )
 
 
-@command(Arg("arg", default="", help="area id (blank = current)"))
-def ooc_cmd_getarea(client, arg):
+@command(Arg("area_id", type=int, default=None, help="area id (blank = current)"))
+def ooc_cmd_getarea(client, area_id):
     """
     Show information about the current area, or target area id with sufficient permissions.
     Usage: /getarea [id]
     """
     aid = client.area.id
-    if arg.strip().isnumeric():
-        area = client.area.area_manager.get_area_by_id(int(arg))
+    if area_id is not None:
+        area = client.area.area_manager.get_area_by_id(area_id)
         if area.id == client.area.id or (client.is_mod or client in area.owners):
-            aid = int(arg)
+            aid = area_id
         else:
             raise ClientError(
                 "Can't see that area - insufficient permissions!")
@@ -335,18 +338,18 @@ def ooc_cmd_gethubs(client):
     """
     client.send_hubs_clients()
 
-@command(Arg("arg", default="", help="area id (blank = current)"))
-def ooc_cmd_getlink(client, arg):
+@command(Arg("area_id", type=int, default=None, help="area id (blank = current)"))
+def ooc_cmd_getlink(client, area_id):
     """
     Show information about the current area, or target area id with sufficient permissions.
     Including the client's link.
     Usage: /getlink [id]
     """
     aid = client.area.id
-    if arg.strip().isnumeric():
-        area = client.area.area_manager.get_area_by_id(int(arg))
+    if area_id is not None:
+        area = client.area.area_manager.get_area_by_id(area_id)
         if area.id == client.area.id or (client.is_mod or client in area.owners):
-            aid = int(arg)
+            aid = area_id
         else:
             raise ClientError(
                 "Can't see that area - insufficient permissions!")
@@ -362,30 +365,25 @@ def ooc_cmd_getlinks(client):
     """
     client.send_areas_clients(show_links=True)
 
-@command(Arg("arg", default="", help="all or blank"))
-def ooc_cmd_getafk(client, arg):
+@command(Arg("scope", default="", choices=("", "all"), help="all or blank"))
+def ooc_cmd_getafk(client, scope):
     """
     Show currently AFK-ing players in the current area or in all areas.
     Usage: /getafk [all]
     """
-    if arg == "all":
-        arg = -1
-    elif len(arg) == 0:
-        arg = client.area.id
-    else:
-        raise ArgumentError("There is only one optional argument [all].")
-    client.send_area_info(arg, afk_check=True)
+    aid = -1 if scope == "all" else client.area.id
+    client.send_area_info(aid, afk_check=True)
 
 
 @mod_only(area_owners=True)
-@command(Arg("arg", rest=True, default="", help="client ID or * (blank lists invites)"))
-def ooc_cmd_invite(client, arg):
+@command(Arg("target", default="", help="client ID or * (blank lists invites)"))
+def ooc_cmd_invite(client, target):
     """
     Allow a particular user to join a locked or speak in spectator-only area.
     ID can be * to invite everyone in the current area.
     Usage: /invite <id>
     """
-    if not arg:
+    if not target:
         msg = "Current invite list:\n"
         msg += "\n".join(
             [
@@ -398,10 +396,8 @@ def ooc_cmd_invite(client, arg):
         client.send_ooc(msg)
         return
 
-    args = arg.split(" ")
-
     try:
-        if args[0] == "*":
+        if target == "*":
             targets = [
                 c
                 for c in client.area.clients
@@ -409,7 +405,7 @@ def ooc_cmd_invite(client, arg):
             ]
         else:
             targets = client.server.client_manager.get_targets(
-                client, TargetType.ID, int(args[0]), False
+                client, TargetType.ID, int(target), False
             )
     except ValueError:
         raise ArgumentError("Area ID must be a number or *.")
@@ -426,18 +422,15 @@ def ooc_cmd_invite(client, arg):
 
 
 @mod_only(area_owners=True)
-@command(Arg("arg", rest=True, default="", help="client ID or *"))
-def ooc_cmd_uninvite(client, arg):
+@command(Arg("target", help="client ID or *"))
+def ooc_cmd_uninvite(client, target):
     """
     Revoke an invitation for a particular user.
     ID can be * to uninvite everyone in the area.
     Usage: /uninvite <id>
     """
-    if not arg:
-        raise ClientError("You must specify a target. Use /uninvite <id>")
-    args = arg.split(" ")
     try:
-        if args[0] == "*":
+        if target == "*":
             targets = [
                 c
                 for c in client.area.clients
@@ -445,7 +438,7 @@ def ooc_cmd_uninvite(client, arg):
             ]
         else:
             targets = client.server.client_manager.get_targets(
-                client, TargetType.ID, int(args[0]), False
+                client, TargetType.ID, int(target), False
             )
     except ValueError:
         raise ArgumentError("Area ID must be a number or *.")
@@ -469,8 +462,12 @@ def ooc_cmd_uninvite(client, arg):
 
 
 @mod_only(area_owners=True)
-@command(Arg("arg", rest=True, default="", help="<id> [destination] [target_pos]"))
-def ooc_cmd_area_kick(client, arg):
+@command(
+    Arg("target", help="*|**|***|afk|id|name"),
+    Arg("destination", type=int, default=None, help="destination area id"),
+    Arg("target_pos", rest=True, default="", help="target position"),
+)
+def ooc_cmd_area_kick(client, target, destination, target_pos):
     """
     Remove a user from the current area and move them to another area.
     If id is a * char, it will kick everyone but you and CMs from current area to destination.
@@ -481,33 +478,26 @@ def ooc_cmd_area_kick(client, arg):
     target_pos is the optional position that everyone should end up in when kicked.
     Usage: /area_kick <id> [destination] [target_pos]
     """
-    if not arg:
-        raise ClientError(
-            "You must specify a target. Use /area_kick <id> [destination] [target_pos]"
-        )
-
-    args = shlex.split(arg)
-
     # Kick everyone but AFKers
-    if args[0] == "afk":
+    if target == "afk":
         targets = client.server.client_manager.get_targets(
-            client, TargetType.AFK, args[0], False
+            client, TargetType.AFK, target, False
         )
     # Kick everyone but owners
-    elif args[0] == "*":
+    elif target == "*":
         targets = [
             c
             for c in client.area.clients
             if c != client and c != client.area.owners
         ]
     # Kick everyone in area
-    elif args[0] == "**":
+    elif target == "**":
         targets = [
             c
             for c in client.area.clients
         ]
     # Kick everyone in hub
-    elif args[0] == "***":
+    elif target == "***":
         targets = [
             c
             for c in client.area.area_manager.clients
@@ -515,22 +505,22 @@ def ooc_cmd_area_kick(client, arg):
     else:
         # Try to find by char name first
         targets = client.server.client_manager.get_targets(
-            client, TargetType.CHAR_NAME, args[0]
+            client, TargetType.CHAR_NAME, target
         )
         # If that doesn't work, find by client ID
-        if len(targets) == 0 and args[0].isdigit():
+        if len(targets) == 0 and target.isdigit():
             targets = client.server.client_manager.get_targets(
-                client, TargetType.ID, int(args[0])
+                client, TargetType.ID, int(target)
             )
         # If that doesn't work, find by OOC Name
         if len(targets) == 0:
             targets = client.server.client_manager.get_targets(
-                client, TargetType.OOC_NAME, args[0]
+                client, TargetType.OOC_NAME, target
             )
 
     if len(targets) == 0:
         client.send_ooc(
-            f"No targets found by search term '{args[0]}'."
+            f"No targets found by search term '{target}'."
         )
         return
 
@@ -545,12 +535,11 @@ def ooc_cmd_area_kick(client, arg):
                 raise ArgumentError(
                     "You can't kick someone from another area as a CM!"
                 )
-            if len(args) == 1:
+            if destination is None:
                 area = client.area
             else:
                 try:
-                    area = client.area.area_manager.get_area_by_id(
-                        int(args[1]))
+                    area = client.area.area_manager.get_area_by_id(destination)
                 except AreaError:
                     raise
                 if (
@@ -561,10 +550,7 @@ def ooc_cmd_area_kick(client, arg):
                     raise ArgumentError(
                         "You can't kick someone to an area you don't own as a CM!"
                     )
-            target_pos = ""
             old_area = c.area
-            if len(args) >= 3:
-                target_pos = args[2]
             c.set_area(area, target_pos)
             c.send_ooc(
                 f"You were kicked from [{old_area.id}] {old_area.name} to [{area.id}] {area.name}."
@@ -576,8 +562,6 @@ def ooc_cmd_area_kick(client, arg):
             client.send_ooc(
                 f"Kicked [{c.id}] {c.showname} from [{old_area.id}] {old_area.name} to [{area.id}] {area.name}."
             )
-    except ValueError:
-        raise ArgumentError("Area ID must be a number.")
     except AreaError:
         raise
     except ClientError:
@@ -662,42 +646,42 @@ def ooc_cmd_pos_lock_clear(client):
     client.area.broadcast_ooc("Position lock cleared.")
 
 
-@command(Arg("arg", rest=True, default="", help="area name or ID"))
-def ooc_cmd_knock(client, arg):
+@command(Arg("area", rest=True, help="area name or ID"))
+def ooc_cmd_knock(client, area):
     """
     Knock on the target area ID to call on their attention to your area.
     Usage:  /knock <id>
     """
-    if arg == "":
+    if not area:
         raise ArgumentError(
             "Failed to knock: you need to input an accessible area name or ID to knock!"
         )
     if client.blinded:
         raise ClientError("Failed to knock: you are blinded!")
     try:
-        area = None
+        target = None
         for _area in client.area.area_manager.areas:
             if (
-                _area.name.lower() == arg.lower()
-                or _area.abbreviation == arg
-                or (arg.isdigit() and _area.id == int(arg))
+                _area.name.lower() == area.lower()
+                or _area.abbreviation == area
+                or (area.isdigit() and _area.id == int(area))
             ):
-                area = _area
+                target = _area
                 break
-        if area is None:
+        if target is None:
             raise ClientError("Target area not found.")
 
-        allowed = client.is_mod or client in area.owners or client in client.area.owners
-        if not allowed and area != client.area:
+        allowed = client.is_mod or client in target.owners or client in client.area.owners
+        if not allowed and target != client.area:
             if len(client.area.links) > 0:
-                if not str(area.id) in client.area.links:
+                if not str(target.id) in client.area.links:
                     raise ClientError(
-                        f"Failed to knock on [{area.id}] {area.name}: That area is inaccessible!"
+                        f"Failed to knock on [{target.id}] {target.name}: That area is inaccessible!"
                     )
 
-                if str(area.id) in client.area.links:
+                if str(target.id) in client.area.links:
                     # Get that link reference
-                    link = client.area.links[str(area.id)]
+                    link = client.area.links[str(target.id)]
 
                     # Link requires us to be inside a piece of evidence
                     if (
@@ -705,11 +689,11 @@ def ooc_cmd_knock(client, arg):
                         and client.hidden_in not in link["evidence"]
                     ):
                         raise ClientError(
-                            f"Failed to knock on [{area.id}] {area.name}: That area is inaccessible!"
+                            f"Failed to knock on [{target.id}] {target.name}: That area is inaccessible!"
                         )
             if client.area.locked and client.id not in client.area.invite_list:
                 raise ClientError(
-                    f"Failed to knock on [{area.id}] {area.name}: Current area is locked!"
+                    f"Failed to knock on [{target.id}] {target.name}: Current area is locked!"
                 )
 
         for c in client.area.clients:
@@ -718,15 +702,15 @@ def ooc_cmd_knock(client, arg):
                 c.send_command("MS", 0, "", "","", "", "", "", 0, -1, 0, 0, 0, 0, 7, 0, "")
             else:
                 c.send_command("RT", "knock")
-        if area == client.area:
-            area.broadcast_ooc(
+        if target == client.area:
+            target.broadcast_ooc(
                 f"💢 [{client.id}] {client.showname} knocks for attention. 💢"
             )
         else:
             client.area.broadcast_ooc(
-                f"[{client.id}] {client.showname} knocks on [{area.id}] {area.name}."
+                f"[{client.id}] {client.showname} knocks on [{target.id}] {target.name}."
             )
-            area.broadcast_ooc(
+            target.broadcast_ooc(
                 f"💢 Someone is knocking from [{client.area.id}] {client.area.name} 💢"
             )
     except ValueError:
@@ -737,39 +721,39 @@ def ooc_cmd_knock(client, arg):
         raise
 
 
-@command(Arg("arg", rest=True, default="", help="area name or ID"))
-def ooc_cmd_peek(client, arg):
+@command(Arg("area", rest=True, help="area name or ID"))
+def ooc_cmd_peek(client, area):
     """
     Peek into an area to see if there's people in it.
     Usage:  /peek <id>
     """
-    if arg == "":
+    if not area:
         raise ArgumentError(
             "You need to input an accessible area name or ID to peek into it!"
         )
     if client.blinded:
         raise ClientError("You are blinded!")
     try:
-        area = None
+        target = None
         for _area in client.area.area_manager.areas:
             if (
-                _area.name.lower() == arg.lower()
-                or _area.abbreviation == arg
-                or (arg.isdigit() and _area.id == int(arg))
+                _area.name.lower() == area.lower()
+                or _area.abbreviation == area
+                or (area.isdigit() and _area.id == int(area))
             ):
-                area = _area
+                target = _area
                 break
-        if area is None:
+        if target is None:
             raise ClientError("Target area not found.")
-        if area == client.area:
+        if target == client.area:
             ooc_cmd_getarea(client, "")
             return
 
         try:
-            client.try_access_area(area, True)
-            if not area.can_getarea:
+            client.try_access_area(target, True)
+            if not target.can_getarea:
                 raise ClientError("Can't peek in that area!")
-            if area.dark:
+            if target.dark:
                 raise ClientError("Area is dark!")
         except ClientError as ex:
             if (
@@ -779,19 +763,19 @@ def ooc_cmd_peek(client, arg):
                 and "locked" in str(ex).lower()
             ):
                 client.area.broadcast_ooc(
-                    f"[{client.id}] {client.showname} tried to peek into [{area.id}] {area.name} but {str(ex).lower()}"
+                    f"[{client.id}] {client.showname} tried to peek into [{target.id}] {target.name} but {str(ex).lower()}"
                 )
                 # People from within the area have no distinction between peeking and moving inside
-                area.broadcast_ooc(
+                target.broadcast_ooc(
                     f"Someone tried to enter from [{client.area.id}] {client.area.name} but {str(ex).lower()}"
                 )
             client.send_ooc(
-                f"Failed to peek into [{area.id}] {area.name}: {ex}")
+                f"Failed to peek into [{target.id}] {target.name}: {ex}")
             return
         else:
             sorted_clients = []
-            for c in area.clients:
-                if not c.hidden and c not in area.owners and not c.is_mod:  # pure IC
+            for c in target.clients:
+                if not c.hidden and c not in target.owners and not c.is_mod:  # pure IC
                     sorted_clients.append(c)
 
             _sort = [
@@ -812,11 +796,11 @@ def ooc_cmd_peek(client, arg):
 
             if not client.sneaking and not client.hidden:
                 client.area.broadcast_ooc(
-                    f"[{client.id}] {client.showname} peeks into [{area.id}] {area.name}..."
+                    f"[{client.id}] {client.showname} peeks into [{target.id}] {target.name}..."
                 )
             else:
                 client.send_ooc(
-                    f"You silently peek into [{area.id}] {area.name}...")
+                    f"You silently peek into [{target.id}] {target.name}...")
             client.send_ooc(f"There's {sorted_clients}.")
     except ValueError:
         raise ArgumentError(
@@ -827,7 +811,7 @@ def ooc_cmd_peek(client, arg):
 
 
 @mod_only(area_owners=True)
-@command(Arg("num", int, default=None, help="max players (-1..99, blank shows)"))
+@command(Arg("num", int, default=None, help="max players (-1..99, blank shows current)"))
 def ooc_cmd_max_players(client, num):
     """
     Set a max amount of players for current area between -1 and 99.

--- a/server/commands/battle.py
+++ b/server/commands/battle.py
@@ -6,7 +6,7 @@ import shlex
 from server.client_manager import ClientManager
 from server.constants import derelative
 
-from . import mod_only
+from . import mod_only, command, Arg
 from .. import commands
 
 __all__ = [
@@ -102,6 +102,7 @@ def send_stats_fighter(client):
     client.send_ooc(msg)
 
 
+@command(Arg("arg", rest=True, default="", help="fighter name"))
 def ooc_cmd_choose_fighter(client, arg):
     """
     Allow you to choose a fighter from the list of the server.
@@ -119,7 +120,8 @@ def ooc_cmd_choose_fighter(client, arg):
         client.send_ooc("No fighter has this name!")
 
 
-def ooc_cmd_info_fighter(client, arg):
+@command()
+def ooc_cmd_info_fighter(client):
     """
     Send info about your fighter.
     Usage: /info_fighter
@@ -130,33 +132,29 @@ def ooc_cmd_info_fighter(client, arg):
         client.send_ooc("You have to choose a fighter first!")
 
 
-def ooc_cmd_create_fighter(client, arg):
+@command(
+    Arg("name", help="fighter name"),
+    Arg("hp", float),
+    Arg("mana", float),
+    Arg("atk", float),
+    Arg("def", float),
+    Arg("spa", float),
+    Arg("spd", float),
+    Arg("spe", float),
+)
+def ooc_cmd_create_fighter(client, name, hp, mana, atk, defe, spa, spd, spe):
     """
     Allow you to create a fighter and to customize its stats.
     Usage: /create_fighter FighterName HP MANA ATK DEF SPA SPD SPE
     """
-    args = shlex.split(arg)
-
-    if len(args) > 8:
-        client.send_ooc(
-            "Too many arguments...\nUsage: /create_fighter FighterName HP MANA ATK DEF SPA SPD SPE"
-        )
-        return
-
-    if len(args) < 8:
-        client.send_ooc(
-            "Not enough arguments...\nUsage: /create_fighter FighterName HP MANA ATK DEF SPA SPD SPE"
-        )
-        return
-
     if (
-        float(args[1]) <= 0
-        or float(args[2]) < 0
-        or float(args[3]) < 0
-        or float(args[4]) < 0
-        or float(args[5]) < 0
-        or float(args[6]) < 0
-        or float(args[7]) < 0
+        hp <= 0
+        or mana < 0
+        or atk < 0
+        or defe < 0
+        or spa < 0
+        or spd < 0
+        or spe < 0
     ):
         client.send_ooc(
             "mana, atk, def, spa, spd, spe have to be greater than or equal to zero\nhp has to be greater than zero\nUsage: /create_fighter FighterName HP MANA ATK DEF SPA SPD SPE"
@@ -165,19 +163,19 @@ def ooc_cmd_create_fighter(client, arg):
 
     fighter_list = os.listdir("storage/battlesystem")
 
-    path = derelative(args[0].lower())
+    path = derelative(name.lower())
     if f"{path}.yaml" in fighter_list:
         client.send_ooc("This fighter has already been created.")
         return
 
     fighter = {}
-    fighter["HP"] = float(args[1])
-    fighter["MANA"] = float(args[2])
-    fighter["ATK"] = float(args[3])
-    fighter["DEF"] = float(args[4])
-    fighter["SPA"] = float(args[5])
-    fighter["SPD"] = float(args[6])
-    fighter["SPE"] = float(args[7])
+    fighter["HP"] = hp
+    fighter["MANA"] = mana
+    fighter["ATK"] = atk
+    fighter["DEF"] = defe
+    fighter["SPA"] = spa
+    fighter["SPD"] = spd
+    fighter["SPE"] = spe
     fighter["Moves"] = []
 
     with open(
@@ -189,7 +187,15 @@ def ooc_cmd_create_fighter(client, arg):
         client.send_ooc(f"{path} has been created!")
 
 
-def ooc_cmd_create_move(client, arg):
+@command(
+    Arg("name", help="move name"),
+    Arg("cost", float),
+    Arg("type", choices=["atk", "spa"], help="atk or spa"),
+    Arg("power", float),
+    Arg("accuracy", float, help="1-100"),
+    Arg("effects", variadic=True, default=[], help="battle effects"),
+)
+def ooc_cmd_create_move(client, name, cost, type, power, accuracy, effects):
     """
     Allow you to create a move for a fighter.
     You have to choose a fighter first!
@@ -202,35 +208,21 @@ def ooc_cmd_create_move(client, arg):
         )
         return
 
-    args = shlex.split(arg)
-
-    if len(args) < 5:
-        client.send_ooc(
-            "Not enough arguments...\nUsage: /create_move MoveName ManaCost MovesType Power Accuracy Effects"
-        )
-        return
-
-    if float(args[1]) < 0:
+    if cost < 0:
         client.send_ooc(
             "ManaCost has to be greater than or equal to zero.\nUsage: /create_move MoveName ManaCost MovesType Power Accuracy Effects"
         )
         return
 
-    if float(args[3]) < 0:
+    if power < 0:
         client.send_ooc(
             "Power has to be greater than or equal to zero.\nUsage: /create_move MoveName ManaCost MovesType Power Accuracy Effects"
         )
         return
 
-    if float(args[4]) <= 0 or float(args[4]) > 100:
+    if accuracy <= 0 or accuracy > 100:
         client.send_ooc(
             "Accuracy should be a integer between 1 and 100\nUsage: /create_move MoveName ManaCost MovesType Power Accuracy Effects"
-        )
-        return
-
-    if args[2].lower() not in ["atk", "spa"]:
-        client.send_ooc(
-            "Move's Type should be atk or spa!\nUsage: /create_move MoveName ManaCost MovesType Power Accuracy Effects"
         )
         return
 
@@ -243,21 +235,21 @@ def ooc_cmd_create_move(client, arg):
         for i in range(0, len(char["Moves"])):
             move_list.append(char["Moves"][i]["Name"])
 
-        if args[0].lower() in move_list:
+        if name.lower() in move_list:
             client.send_ooc("This move has already been created.")
             return
 
         char["Moves"].append({})
         index = len(char["Moves"]) - 1
-        char["Moves"][index]["Name"] = args[0].lower()
-        char["Moves"][index]["ManaCost"] = float(args[1])
-        char["Moves"][index]["MovesType"] = args[2].lower()
-        char["Moves"][index]["Power"] = float(args[3])
-        char["Moves"][index]["Accuracy"] = float(args[4])
+        char["Moves"][index]["Name"] = name.lower()
+        char["Moves"][index]["ManaCost"] = cost
+        char["Moves"][index]["MovesType"] = type.lower()
+        char["Moves"][index]["Power"] = power
+        char["Moves"][index]["Accuracy"] = accuracy
         char["Moves"][index]["Effects"] = []
-        for i in range(5, len(args)):
-            if args[i].lower() in battle_effects:
-                char["Moves"][index]["Effects"].append(args[i].lower())
+        for effect in effects:
+            if effect.lower() in battle_effects:
+                char["Moves"][index]["Effects"].append(effect.lower())
         with open(
             f"storage/battlesystem/{client.battle.fighter}.yaml",
             "w",
@@ -265,7 +257,7 @@ def ooc_cmd_create_move(client, arg):
         ) as c_save:
             yaml.dump(char, c_save)
 
-        client.send_ooc(f"{args[0]} has been added!")
+        client.send_ooc(f"{name} has been added!")
         client.battle = ClientManager.BattleChar(client, client.battle.fighter, char)
         guild = None
         for g in client.area.battle_guilds:
@@ -276,26 +268,22 @@ def ooc_cmd_create_move(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_modify_stat(client, arg):
+@command(
+    Arg("name", help="fighter name"),
+    Arg("stat", choices=["hp", "mana", "atk", "def", "spa", "spd", "spe"]),
+    Arg("value", float),
+)
+def ooc_cmd_modify_stat(client, name, stat, value):
     """
     Allow you to modify fighter's stats.
     Usage: /modify_stat FighterName Stat Value
     """
-    args = shlex.split(arg)
-    
-    
-    path = derelative(args[0].lower())
+    path = derelative(name.lower())
     if f"{path}.yaml" not in os.listdir("storage/battlesystem"):
         client.send_ooc("No fighter has this name!")
         return
 
-    if args[1].lower() not in ["hp", "mana", "atk", "def", "spa", "spd", "spe"]:
-        client.send_ooc(
-            "You could just modify this stats:\nhp, mana, atk, def, spa, spd, spe"
-        )
-        return
-
-    if float(args[2]) < 0:
+    if value < 0:
         client.send_ooc("The value have to be a number greater than or equal to zero")
         return
 
@@ -303,17 +291,18 @@ def ooc_cmd_modify_stat(client, arg):
         f"storage/battlesystem/{path}.yaml", "r", encoding="utf-8"
     ) as c_load:
         char = yaml.safe_load(c_load)
-        char[args[1].upper()] = float(args[2])
+        char[stat.upper()] = value
         with open(
             f"storage/battlesystem/{path}.yaml", "w", encoding="utf-8"
         ) as c_save:
             yaml.dump(char, c_save)
     client.send_ooc(
-        f"{path}'s {args[1]} has been modified. To check the changes choose again this fighter"
+        f"{path}'s {stat} has been modified. To check the changes choose again this fighter"
     )
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="fighter name"))
 def ooc_cmd_delete_fighter(client, arg):
     """
     Allow you to delete a fighter.
@@ -327,6 +316,7 @@ def ooc_cmd_delete_fighter(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="move name"))
 def ooc_cmd_delete_move(client, arg):
     """
     Delete a move from a fighter.
@@ -370,50 +360,50 @@ def ooc_cmd_delete_move(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_battle_config(client, arg):
+@command(
+    Arg("parameter", default="", help="setting name (blank lists all)"),
+    Arg("value", default="", help="new value"),
+)
+def ooc_cmd_battle_config(client, parameter, value):
    """
    Allow you to customize some battle settings.
    Usage: /custom_battle <parameter> <value>
    """
-   if arg == "":
+   if parameter == "":
        client.send_ooc(
            "paralysis_rate, critical_rate, critical_bonus, bonus_malus, poison_damage, show_hp, min_multishot, max_multishot, burn_damage, freeze_damage, confusion_rate, enraged_bonus, stolen_stat"
        )
        return
-   args = arg.split(" ")
-   if args[0].lower() == "paralysis_rate":
-       client.area.battle_paralysis_rate = int(args[1])
-   elif args[0].lower() == "critical_rate":
-       client.area.battle_critical_rate = int(args[1])
-   elif args[0].lower() == "critical_bonus":
-       client.area.battle_critical_bonus = float(args[1])
-   elif args[0].lower() == "bonus_malus":
-       client.area.battle_bonus_malus = float(args[1])
-   elif args[0].lower() == "poison_damage":
-       client.area.battle_poison_damage = float(args[1])
-   elif args[0].lower() == "min_multishot":
-       client.area.battle_min_multishot = int(args[1])
-   elif args[0].lower() == "max_multishot":
-       client.area.battle_max_multishot = int(args[1])
-   elif args[0].lower() == "burn_damage":
-       client.area.battle_burn_damage = float(args[1])
-   elif args[0].lower() == "freeze_damage":
-       client.area.battle_freeze_damage = float(args[1])
-   elif args[0].lower() == "confusion_rate":
-       client.area.battle_confusion_rate = int(args[1])
-   elif args[0].lower() == "enraged_bonus":
-       client.area.battle_enraged_bonus = float(args[1])
-   elif args[0].lower() == "stolen_stat":
-       client.area.battle_stolen_stat = float(args[1])
-   elif args[1].lower() in ["true", "false"] and args[0].lower() == "show_hp":
-       if args[1].lower() == "true":
-           client.area.battle_show_hp = True
-       else:
-           client.area.battle_show_hp = False
+   if parameter.lower() == "paralysis_rate":
+       client.area.battle_paralysis_rate = int(value)
+   elif parameter.lower() == "critical_rate":
+       client.area.battle_critical_rate = int(value)
+   elif parameter.lower() == "critical_bonus":
+       client.area.battle_critical_bonus = float(value)
+   elif parameter.lower() == "bonus_malus":
+       client.area.battle_bonus_malus = float(value)
+   elif parameter.lower() == "poison_damage":
+       client.area.battle_poison_damage = float(value)
+   elif parameter.lower() == "min_multishot":
+       client.area.battle_min_multishot = int(value)
+   elif parameter.lower() == "max_multishot":
+       client.area.battle_max_multishot = int(value)
+   elif parameter.lower() == "burn_damage":
+       client.area.battle_burn_damage = float(value)
+   elif parameter.lower() == "freeze_damage":
+       client.area.battle_freeze_damage = float(value)
+   elif parameter.lower() == "confusion_rate":
+       client.area.battle_confusion_rate = int(value)
+   elif parameter.lower() == "enraged_bonus":
+       client.area.battle_enraged_bonus = float(value)
+   elif parameter.lower() == "stolen_stat":
+       client.area.battle_stolen_stat = float(value)
+   elif parameter.lower() == "show_hp" and value.lower() in ["true", "false"]:
+       client.area.battle_show_hp = value.lower() == "true"
    else:
        client.send_ooc("value is not valid")
        return
-   client.send_ooc(f"{args[0].lower()} has been changed to {args[1]}")
+   client.send_ooc(f"{parameter.lower()} has been changed to {value}")
 
 
 def send_battle_info(client):
@@ -456,7 +446,8 @@ def send_battle_info(client):
     return msg
 
 
-def ooc_cmd_battle_info(client, arg):
+@command()
+def ooc_cmd_battle_info(client):
     """
     Send you info about the battle.
     Usage: /battle_info
@@ -468,7 +459,8 @@ def ooc_cmd_battle_info(client, arg):
         client.send_ooc("You are not fighting!")
 
 
-def ooc_cmd_fight(client, arg):
+@command()
+def ooc_cmd_fight(client):
     """
     Allow you to join the battle or rejoin if you disconnected!
     Usage: /fight
@@ -529,7 +521,8 @@ def ooc_cmd_fight(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_refresh_battle(client, arg):
+@command()
+def ooc_cmd_refresh_battle(client):
     """
     Refresh the battle
     Usage: /refresh_battle
@@ -542,7 +535,8 @@ def ooc_cmd_refresh_battle(client, arg):
     client.send_ooc("The battle has been refreshed!")
 
 
-def ooc_cmd_surrender(client, arg):
+@command()
+def ooc_cmd_surrender(client):
     """
     A command to surrend from the current battle.
     Usage: /surrender
@@ -579,14 +573,15 @@ def ooc_cmd_surrender(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_remove_fighter(client, arg):
+@command(Arg("id", int, help="target client ID"))
+def ooc_cmd_remove_fighter(client, id):
     """
     Force a fighter to leave the battle.
     Usage: /remove_fighter Target_ID
     """
     fighter_ids = {c.id: c for c in client.area.fighters}
-    if int(arg) in fighter_ids:
-        target = fighter_ids[int(arg)]
+    if id in fighter_ids:
+        target = fighter_ids[id]
         if target.battle.selected_move == -1:
             client.area.fighters.remove(target)
         else:
@@ -620,18 +615,19 @@ def ooc_cmd_remove_fighter(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_force_skip_move(client, arg):
+@command(Arg("id", int, help="target client ID"))
+def ooc_cmd_force_skip_move(client, id):
     """
     Force a fighter to skip the turn
     Usage: /force_skip_move Target_ID
     """
 
     fighter_ids = {c.id: c for c in client.area.fighters}
-    if int(arg) not in fighter_ids:
+    if id not in fighter_ids:
         client.send_ooc("The target is not in the fighter list")
         return
 
-    target = fighter_ids[int(arg)]
+    target = fighter_ids[id]
 
     if target.battle.selected_move == -1:
         target.area.num_selected_move += 1
@@ -650,7 +646,8 @@ def ooc_cmd_force_skip_move(client, arg):
             client.area.battle_started = False
 
 
-def ooc_cmd_skip_move(client, arg):
+@command()
+def ooc_cmd_skip_move(client):
     """
     Allow you to skip the turn
     Usage: /skip_move
@@ -676,6 +673,8 @@ def ooc_cmd_skip_move(client, arg):
             client.area.battle_started = False
 
 
+@mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="guild name (blank closes all)"))
 def ooc_cmd_close_guild(client, arg):
     """
     Allow GM to close all guilds if arg is "", or to close a specific guild is arg is GuildName
@@ -695,7 +694,8 @@ def ooc_cmd_close_guild(client, arg):
         client.send_ooc("Guild not found!")
 
 
-def ooc_cmd_battle_effects(client, arg):
+@command()
+def ooc_cmd_battle_effects(client):
     """
     Show all available battle effects
     Usage: /battle_effects
@@ -706,12 +706,15 @@ def ooc_cmd_battle_effects(client, arg):
     client.send_ooc(msg)
 
 
-def ooc_cmd_leave_guild(client, arg):
+@command(
+    Arg("id", int, default=None, help="target client ID (blank leaves yourself)"),
+)
+def ooc_cmd_leave_guild(client, id):
     """
     Allow you to leave your current guid
     Usage: /leave_guild <Target_ID>
     """
-    if arg == "":
+    if id is None:
         if client.battle.guild is None:
             client.send_ooc("You are not in any guilds!")
             return
@@ -725,8 +728,8 @@ def ooc_cmd_leave_guild(client, arg):
     else:
         if client in client.area.area_manager.owners:
             area_ids = {c.id: c for c in client.area.clients}
-            if int(arg) in area_ids:
-                target = area_ids[int(arg)]
+            if id in area_ids:
+                target = area_ids[id]
                 if target.battle is None or target.battle.guild is None:
                     client.send_ooc("Target has not a fighter or is not in a guild!")
                     return
@@ -743,8 +746,8 @@ def ooc_cmd_leave_guild(client, arg):
             guild_ids = {
                 c.id: c for c in client.area.battle_guilds[client.battle.guild]
             }
-            if int(arg) in guild_ids:
-                target = guild_ids[int(arg)]
+            if id in guild_ids:
+                target = guild_ids[id]
                 guild = target.battle.guild
                 client.area.battle_guilds[guild].remove(target)
                 if len(client.area.battle_guilds[guild]) == 0:
@@ -758,7 +761,8 @@ def ooc_cmd_leave_guild(client, arg):
             client.send_ooc("You are not a GM or a Guild Leader")
 
 
-def ooc_cmd_join_guild(client, arg):
+@command(Arg("id", int, help="target client ID"))
+def ooc_cmd_join_guild(client, id):
     """
     Allow the guild leader to let a fighter to join the guild
     Usage: /join_guild <Target_ID>
@@ -781,11 +785,11 @@ def ooc_cmd_join_guild(client, arg):
 
     area_ids = {c.id: c for c in client.area.clients}
 
-    if int(arg) not in area_ids:
+    if id not in area_ids:
         client.send_ooc("Target not found!")
         return
 
-    target = area_ids[int(arg)]
+    target = area_ids[id]
 
     if target.battle is None:
         client.send_ooc(f"{client.showname} has to choose a fighter first!")
@@ -807,6 +811,7 @@ def ooc_cmd_join_guild(client, arg):
         send_info_guild(client)
 
 
+@command(Arg("arg", rest=True, default="", help="guild name"))
 def ooc_cmd_create_guild(client, arg):
     """
     Allow you to create a guild
@@ -827,7 +832,8 @@ def ooc_cmd_create_guild(client, arg):
     send_info_guild(client)
 
 
-def ooc_cmd_info_guild(client, arg):
+@command()
+def ooc_cmd_info_guild(client):
     """
     Send info about your guild
     Usage: /info_guild
@@ -861,7 +867,11 @@ def send_info_guild(client):
     client.send_ooc(msg)
 
 
-def ooc_cmd_use_move(client, arg):
+@command(
+    Arg("move", help="move name or ID"),
+    Arg("target", int, default=None, help="target client ID"),
+)
+def ooc_cmd_use_move(client, move, target):
     """
     This command will let you use a move during a battle!
     AttAll moves don't need a target!
@@ -879,35 +889,34 @@ def ooc_cmd_use_move(client, arg):
     if client.battle.current_client is None:
         client.battle.current_client = client
 
-    args = shlex.split(arg)
-    if args[0].isnumeric():
-        if int(args[0]) > len(client.battle.moves):
+    if move.isnumeric():
+        if int(move) > len(client.battle.moves):
             client.send_ooc("There is no move with that ID!")
             return
 
-        move_id = int(args[0])
-        args[0] = client.battle.moves[move_id].name
+        move_id = int(move)
+        move = client.battle.moves[move_id].name
     else:
         moves_list = [move.name for move in client.battle.moves]
 
-        if args[0].lower() not in moves_list:
+        if move.lower() not in moves_list:
             client.send_ooc("There is no move with this name!")
             return
 
-        move_id = moves_list.index(args[0].lower())
+        move_id = moves_list.index(move.lower())
 
     if client.battle.moves[move_id].cost > client.battle.mana:
         client.send_ooc("You don't have enough mana to use this move!")
         return
 
-    if len(args) == 2:
+    if target is not None:
         fighter_id_list = {c.id: c for c in client.area.fighters}
-        if int(args[1]) in fighter_id_list:
-            client.battle.target = fighter_id_list[int(args[1])]
+        if target in fighter_id_list:
+            client.battle.target = fighter_id_list[target]
             client.battle.selected_move = move_id
             client.area.num_selected_move += 1
             client.battle.mana += -client.battle.moves[move_id].cost
-            client.send_ooc(f"You have choosen {args[0].lower()}")
+            client.send_ooc(f"You have choosen {move.lower()}")
             client.area.broadcast_ooc(f"{client.battle.fighter} has choosen a move")
         else:
             client.send_ooc("Your target is not in the fighter list")
@@ -916,7 +925,7 @@ def ooc_cmd_use_move(client, arg):
         client.battle.selected_move = move_id
         client.area.num_selected_move += 1
         client.battle.mana += -client.battle.moves[move_id].cost
-        client.send_ooc(f"You have choosen {args[0].lower()}")
+        client.send_ooc(f"You have choosen {move.lower()}")
         client.area.broadcast_ooc(f"{client.battle.fighter} has choosen a move")
     else:
         client.send_ooc("Not enough argument to attack")

--- a/server/commands/casing.py
+++ b/server/commands/casing.py
@@ -8,7 +8,7 @@ from server import database
 from server.constants import TargetType, derelative
 from server.exceptions import ClientError, ServerError, ArgumentError, AreaError
 
-from . import mod_only
+from . import mod_only, command, Arg, tokens_str
 
 __all__ = [
     "ooc_cmd_doc",
@@ -51,6 +51,7 @@ __all__ = [
     "ooc_cmd_evidence_lists",
 ]
 
+@command(Arg("arg", rest=True, default="", help="url (blank shows current)"))
 def ooc_cmd_doc(client, arg):
     """
     Show or change the link for the current case document.
@@ -75,13 +76,12 @@ def ooc_cmd_doc(client, arg):
         database.log_area("doc.change", client, client.area, message=arg)
 
 
-def ooc_cmd_cleardoc(client, arg):
+@command()
+def ooc_cmd_cleardoc(client):
     """
     Clear the link for the current case document.
     Usage: /cleardoc
     """
-    if len(arg) != 0:
-        raise ArgumentError("This command has no arguments.")
     if client.area.cannot_ic_interact(client):
         raise ClientError("You are not on the area's invite list!")
     if (
@@ -96,6 +96,7 @@ def ooc_cmd_cleardoc(client, arg):
     database.log_area("doc.clear", client, client.area)
 
 
+@command(Arg("arg", rest=True, default="", help="evidence name or id (blank lists all)"))
 def ooc_cmd_evidence(client, arg):
     """
     Use /evidence to read all evidence in the area.
@@ -140,39 +141,26 @@ def ooc_cmd_evidence(client, arg):
         raise
 
 
-def ooc_cmd_evidence_add(client, arg):
+@command(
+    Arg("name", default="<name>", help="evidence name"),
+    Arg("description", default="<description>", help="evidence description"),
+    Arg("image", default="empty.png", help="evidence image"),
+)
+def ooc_cmd_evidence_add(client, name, description, image):
     """
     Add a piece of evidence.
     For sentences with spaces the arg should be surrounded in ""'s, for example /evidence_add Chair "It's a chair." chair.png
     Usage: /evidence_add [name] [desc] [image]
     """
-    try:
-        max_args = 3
-        # Get the user input
-        args = shlex.split(arg)
-        if len(args) > 3:
-            raise ArgumentError(
-                f"Too many arguments! Make sure to surround your args in \"\"'s if there's spaces. (/evidence_add {arg})")
-        # fill the rest of it with asterisk to fill to max_args
-        args = args + ([""] * (max_args - len(args)))
-        if args[0] == "":
-            args[0] = "<name>"
-        if args[1] == "":
-            args[1] = "<description>"
-        if args[2] == "":
-            args[2] = "empty.png"
-    except ValueError as ex:
-        client.send_ooc(f'{ex} (/evidence_add {arg})')
-        return
-
     client.area.evi_list.add_evidence(
-        client, args[0], args[1], args[2]
+        client, name, description, image
     )
     database.log_area("evidence.add", client, client.area)
     client.area.broadcast_evidence_list()
-    client.send_ooc(f"You have added evidence '{args[0]}'.")
+    client.send_ooc(f"You have added evidence '{name}'.")
 
 
+@command(Arg("arg", rest=True, default="", help="evidence name or id"))
 def ooc_cmd_evidence_remove(client, arg):
     """
     Remove a piece of evidence.
@@ -204,51 +192,40 @@ def ooc_cmd_evidence_remove(client, arg):
         raise
 
 
-def ooc_cmd_evidence_edit(client, arg):
+@command(
+    Arg("target_evi", help="evidence name or id"),
+    Arg("name", default="*", help="new evidence name"),
+    Arg("description", default="*", help="new evidence description"),
+    Arg("image", default="*", help="new evidence image"),
+)
+def ooc_cmd_evidence_edit(client, target_evi, name, description, image):
     """
     Edit a piece of evidence.
     If you don't want to change something, put an * there.
     For sentences with spaces the arg should be surrounded in ""'s, for example /evidence_edit * "It's a chair." chair.png
     Usage: /evidence_edit <evi_name/id> [name] [desc] [image]
     """
-    if arg == "":
-        raise ArgumentError(
-            "Use /evidence_edit <evi_name/id> [name] [desc] [image] to edit that piece of evidence."
-        )
-
-    try:
-        max_args = 4
-        # Get the user input
-        args = shlex.split(arg)
-        if len(args) > 4:
-            raise ArgumentError(
-                f"Too many arguments! Make sure to surround your args in \"\"'s if there's spaces. (/evidence_edit {arg})")
-        # fill the rest of it with asterisk to fill to max_args
-        args = args + (["*"] * (max_args - len(args)))
-    except ValueError as ex:
-        client.send_ooc(f'{ex} (/evidence_edit {arg})')
-        return
-
     try:
         evi_list = client.area.get_evidence_list(client)
         evidence = None
         for i, evi in enumerate(evi_list):
-            if (args[0].isnumeric() and int(args[0]) - 1 == i) or args[0].lower() == evi[0].lower():
+            if (target_evi.isnumeric() and int(target_evi) - 1 == i) or target_evi.lower() == evi[0].lower():
                 evidence = evi
                 break
         if evidence is None:
             raise AreaError(
-                f"Target evidence not found! (/evidence_edit {arg})"
+                f"Target evidence not found! (/evidence_edit {target_evi})"
             )
         evi_name = evidence[0]
-        evi = (args[1], args[2], args[3], "all")
+        evi = (name, description, image, "all")
 
         if client.area.evi_list.edit_evidence(client, i, evi):
             database.log_area("evidence.edit", client, client.area)
             client.area.broadcast_evidence_list()
             if evi[0] != "*" and evi_name != evi[0]:
                 client.send_ooc(
-                    f"You have edited evidence '{evi_name}' to '{evi[0]}'.")
+                    f"You have edited evidence '{evi_name}' to '{evi[0]}'."
+                )
             else:
                 client.send_ooc(f"You have edited evidence '{evi_name}'.")
     except ValueError:
@@ -257,6 +234,7 @@ def ooc_cmd_evidence_edit(client, arg):
         raise
 
 
+@command(Arg("arg", rest=True, default="", help="evidence name or id (blank stops)"))
 def ooc_cmd_evidence_present(client, arg):
     """
     Present a piece of evidence on your next IC message.
@@ -291,53 +269,54 @@ def ooc_cmd_evidence_present(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_evidence_mod(client, arg):
+@command(
+    Arg("mode", choices=["FFA", "Mods", "CM", "HiddenCM"], default=None, help="mode (blank shows current)"),
+)
+def ooc_cmd_evidence_mod(client, mode):
     """
     Change the evidence privilege mode. Refer to the documentation
     for more information on the function of each mode.
     Usage: /evidence_mod <FFA|Mods|CM|HiddenCM>
     """
-    if not arg or arg == client.area.evidence_mod:
+    if mode is None or mode == client.area.evidence_mod:
         client.send_ooc(f"current evidence mod: {client.area.evidence_mod}")
-    elif arg in ["FFA", "Mods", "CM", "HiddenCM"]:
+    else:
         if not client.is_mod:
             if client.area.evidence_mod == "Mods":
                 raise ClientError(
                     "You must be authorized to change this area's evidence mod from Mod-only."
                 )
-            if arg == "Mods":
+            if mode == "Mods":
                 raise ClientError(
                     "You must be authorized to set the area's evidence to Mod-only."
                 )
-        client.area.evidence_mod = arg
+        client.area.evidence_mod = mode
         client.area.broadcast_evidence_list()
         client.send_ooc(f"current evidence mod: {client.area.evidence_mod}")
-        database.log_area("evidence_mod", client, client.area, message=arg)
-    else:
-        raise ArgumentError(
-            "Wrong Argument. Use /evidence_mod <MOD>. Possible values: FFA, CM, Mods, HiddenCM"
-        )
+        database.log_area("evidence_mod", client, client.area, message=mode)
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_evidence_swap(client, arg):
+@command(
+    Arg("a", int, help="evidence id"),
+    Arg("b", int, help="evidence id"),
+)
+def ooc_cmd_evidence_swap(client, a, b):
     """
     Swap the positions of two evidence items on the evidence list.
     The ID of each evidence can be displayed by mousing over it in 2.8 client,
     or simply its number starting from 1.
     Usage: /evidence_swap <id> <id>
     """
-    args = list(arg.split(" "))
-    if len(args) != 2:
-        raise ClientError("you must specify 2 numbers")
     try:
         client.area.evi_list.evidence_swap(
-            client, int(args[0]) - 1, int(args[1]) - 1)
+            client, a - 1, b - 1)
         client.area.broadcast_evidence_list()
     except Exception:
         raise ClientError("you must specify 2 numbers")
 
 
+@command(Arg("arg", rest=True, default="", help="client ID(s) or * (blank = self)"))
 def ooc_cmd_cm(client, arg):
     """
     Add a case manager for the current area.
@@ -391,6 +370,7 @@ def ooc_cmd_cm(client, arg):
 
 # TODO: allow running this command from outside the area you're a CM of in hubs that allow multiple CMed areas
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="client ID(s) (blank = self)"))
 def ooc_cmd_uncm(client, arg):
     """
     Remove a case manager from the current area.
@@ -420,6 +400,7 @@ def ooc_cmd_uncm(client, arg):
 
 
 # LEGACY
+@command(Arg("arg", rest=True, default="", help="internal"))
 def ooc_cmd_setcase(client, arg):
     """
     Set the positions you are interested in taking for a case.
@@ -439,6 +420,7 @@ def ooc_cmd_setcase(client, arg):
 
 
 # LEGACY
+@command(Arg("arg", rest=True, default="", help="<message> <def> <pro> <jud> <jur> <steno>"))
 def ooc_cmd_anncase(client, arg):
     """
     Announce that a case is currently taking place in this area,
@@ -501,20 +483,16 @@ def ooc_cmd_anncase(client, arg):
 
 
 @mod_only()
-def ooc_cmd_blockwtce(client, arg):
+@command(Arg("id", int, help="client ID"))
+def ooc_cmd_blockwtce(client, id):
     """
     Prevent a user from using Witness Testimony/Cross Examination buttons
     as a judge.
     Usage: /blockwtce <id>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target. Use /blockwtce <id>.")
-    try:
-        targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(arg), False
-        )
-    except Exception:
-        raise ArgumentError("You must enter a number. Use /blockwtce <id>.")
+    targets = client.server.client_manager.get_targets(
+        client, TargetType.ID, id, False
+    )
     if not targets:
         raise ArgumentError("Target not found. Use /blockwtce <id>.")
     for target in targets:
@@ -525,20 +503,15 @@ def ooc_cmd_blockwtce(client, arg):
 
 
 @mod_only()
-def ooc_cmd_unblockwtce(client, arg):
+@command(Arg("id", int, help="client ID"))
+def ooc_cmd_unblockwtce(client, id):
     """
     Allow a user to use WT/CE again.
     Usage: /unblockwtce <id>
     """
-    if len(arg) == 0:
-        raise ArgumentError(
-            "You must specify a target. Use /unblockwtce <id>.")
-    try:
-        targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(arg), False
-        )
-    except Exception:
-        raise ArgumentError("You must enter a number. Use /unblockwtce <id>.")
+    targets = client.server.client_manager.get_targets(
+        client, TargetType.ID, id, False
+    )
     if not targets:
         raise ArgumentError("Target not found. Use /unblockwtce <id>.")
     for target in targets:
@@ -549,13 +522,12 @@ def ooc_cmd_unblockwtce(client, arg):
 
 
 @mod_only()
-def ooc_cmd_judgelog(client, arg):
+@command()
+def ooc_cmd_judgelog(client):
     """
     List the last 10 uses of judge controls in the current area.
     Usage: /judgelog
     """
-    if len(arg) != 0:
-        raise ArgumentError("This command does not take any arguments.")
     jlog = client.area.judgelog
     if len(jlog) > 0:
         jlog_msg = "== Judge Log =="
@@ -568,12 +540,16 @@ def ooc_cmd_judgelog(client, arg):
         )
 
 
-def ooc_cmd_afk(client, arg):
+@command()
+def ooc_cmd_afk(client):
     client.server.client_manager.toggle_afk(client)
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_remote_listen(client, arg):
+@command(
+    Arg("option", choices=["NONE", "IC", "OOC", "ALL"], default=None, help="option (blank shows current)"),
+)
+def ooc_cmd_remote_listen(client, option):
     """
     Change the remote listen logs to either NONE, IC, OOC or ALL.
     It will send you those messages from the areas you are an owner of.
@@ -586,19 +562,15 @@ def ooc_cmd_remote_listen(client, arg):
         "OOC": 2,
         "ALL": 3,
     }
-    if arg != "":
-        try:
-            client.remote_listen = options[arg.upper()]
-        except KeyError:
-            raise ArgumentError(
-                "Invalid option! Your options are NONE, IC, OOC or ALL."
-            )
+    if option is not None:
+        client.remote_listen = options[option]
     reversed_options = dict(map(reversed, options.items()))
     opt = reversed_options[client.remote_listen]
     client.send_ooc(f"Your current remote listen option is: {opt}")
 
 
-def ooc_cmd_testimony(client, arg):
+@command(Arg("id", int, default=None, help="statement id to move to"))
+def ooc_cmd_testimony(client, id):
     """
     Display the currently recorded testimony.
     Optionally, id can be passed to move to that statement.
@@ -607,19 +579,16 @@ def ooc_cmd_testimony(client, arg):
     if len(client.area.testimony) <= 0:
         client.send_ooc("There is no testimony recorded!")
         return
-    args = arg.split()
-    if len(args) > 0:
+    if id is not None:
         try:
             if client.area.recording is True:
                 client.send_ooc("It is not cross-examination yet!")
                 return
-            idx = int(args[0]) - 1
+            idx = id - 1
             client.area.testimony_send(idx)
             client.area.broadcast_ooc(
                 f"{client.showname} has moved to Statement {idx+1}."
             )
-        except ValueError:
-            raise ArgumentError("Index must be a number!")
         except ClientError:
             raise
         return
@@ -641,6 +610,7 @@ def ooc_cmd_testimony(client, arg):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="testimony title"))
 def ooc_cmd_testimony_start(client, arg):
     """
     Manually start a testimony with the given title.
@@ -648,7 +618,8 @@ def ooc_cmd_testimony_start(client, arg):
     """
     if arg == "":
         raise ArgumentError(
-            "You must provite a title! /testimony_start <title>.")
+            "You must provite a title! /testimony_start <title>."
+        )
     if len(arg) < 3:
         raise ArgumentError("Title must contain at least 3 characters!")
     client.area.testimony.clear()
@@ -661,7 +632,8 @@ def ooc_cmd_testimony_start(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_testimony_continue(client, arg):
+@command()
+def ooc_cmd_testimony_continue(client):
     """
     Continue an existing testimony, restarting the recording so new statements may be added.
     Usage: /testimony_continue
@@ -675,7 +647,8 @@ def ooc_cmd_testimony_continue(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_testimony_clear(client, arg):
+@command()
+def ooc_cmd_testimony_clear(client):
     """
     Clear the current testimony.
     Usage: /testimony_clear
@@ -683,8 +656,6 @@ def ooc_cmd_testimony_clear(client, arg):
     if len(client.area.testimony) <= 0:
         client.send_ooc("There is no testimony recorded!")
         return
-    if len(arg) != 0:
-        raise ArgumentError("This command does not take any arguments.")
     client.area.testimony.clear()
     client.area.testimony_title = ""
     client.area.broadcast_ooc(
@@ -692,7 +663,8 @@ def ooc_cmd_testimony_clear(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_testimony_remove(client, arg):
+@command(Arg("idx", int, help="statement index"))
+def ooc_cmd_testimony_remove(client, idx):
     """
     Remove the statement at index.
     Usage: /testimony_remove <id>
@@ -700,11 +672,8 @@ def ooc_cmd_testimony_remove(client, arg):
     if len(client.area.testimony) <= 0:
         client.send_ooc("There is no testimony recorded!")
         return
-    args = arg.split()
-    if len(args) <= 0:
-        raise ArgumentError("Usage: /testimony_remove <idx>.")
     try:
-        idx = int(args[0]) - 1
+        idx = idx - 1
         client.area.testimony.pop(idx)
         if client.area.testimony_index == idx:
             client.area.testimony_index = -1
@@ -719,7 +688,11 @@ def ooc_cmd_testimony_remove(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_testimony_amend(client, arg):
+@command(
+    Arg("id", int, help="statement index"),
+    Arg("msg", rest=True, default="", help="new message"),
+)
+def ooc_cmd_testimony_amend(client, id, msg):
     """
     Edit the spoken message of the statement at id.
     Usage: /testimony_amend <id> <msg>
@@ -727,13 +700,10 @@ def ooc_cmd_testimony_amend(client, arg):
     if len(client.area.testimony) <= 0:
         client.send_ooc("There is no testimony recorded!")
         return
-    args = arg.split()
-    if len(args) < 2:
-        raise ArgumentError("Usage: /testimony_remove <id> <msg>.")
     try:
-        idx = int(args[0]) - 1
+        idx = id - 1
         lst = list(client.area.testimony[idx])
-        lst[4] = "}}}" + " ".join(args[1:])
+        lst[4] = "}}}" + msg
         client.area.testimony[idx] = tuple(lst)
         client.area.broadcast_ooc(
             f"{client.showname} has amended Statement {idx+1}.")
@@ -746,7 +716,11 @@ def ooc_cmd_testimony_amend(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_testimony_swap(client, arg):
+@command(
+    Arg("idx1", int, help="statement index"),
+    Arg("idx2", int, help="statement index"),
+)
+def ooc_cmd_testimony_swap(client, idx1, idx2):
     """
     Swap the two statements by idx.
     Usage: /testimony_swap <id> <id>
@@ -754,12 +728,9 @@ def ooc_cmd_testimony_swap(client, arg):
     if len(client.area.testimony) <= 0:
         client.send_ooc("There is no testimony recorded!")
         return
-    args = arg.split()
-    if len(args) < 2:
-        raise ArgumentError("Usage: /testimony_remove <id> <id>.")
     try:
-        idx1 = int(args[0]) - 1
-        idx2 = int(args[1]) - 1
+        idx1 = idx1 - 1
+        idx2 = idx2 - 1
         client.area.testimony[idx2], client.area.testimony[idx1] = (
             client.area.testimony[idx1],
             client.area.testimony[idx2],
@@ -776,7 +747,11 @@ def ooc_cmd_testimony_swap(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_testimony_insert(client, arg):
+@command(
+    Arg("idx1", int, help="statement index"),
+    Arg("idx2", int, help="statement index"),
+)
+def ooc_cmd_testimony_insert(client, idx1, idx2):
     """
     Insert the targeted statement at idx.
     Usage: /testimony_insert <id> <id>
@@ -784,12 +759,9 @@ def ooc_cmd_testimony_insert(client, arg):
     if len(client.area.testimony) <= 0:
         client.send_ooc("There is no testimony recorded!")
         return
-    args = arg.split()
-    if len(args) < 2:
-        raise ArgumentError("Usage: /testimony_insert <id> <id>.")
     try:
-        idx1 = int(args[0]) - 1
-        idx2 = int(args[1]) - 1
+        idx1 = idx1 - 1
+        idx2 = idx2 - 1
         statement = client.area.testimony.pop(idx1)
         client.area.testimony.insert(idx2, statement)
 
@@ -804,7 +776,11 @@ def ooc_cmd_testimony_insert(client, arg):
         raise
 
 
-def ooc_cmd_cs(client, arg):
+@command(
+    Arg("id", int, default=None, help="target client ID (blank shows current)"),
+    Arg("pta", default="", help="internal"),
+)
+def ooc_cmd_cs(client, id, pta):
     """
     Start a one-on-one "Cross Swords" debate with targeted player!
     Expires in 5 minutes. If there's an ongoing cross-swords already,
@@ -812,7 +788,7 @@ def ooc_cmd_cs(client, arg):
     with you joining the side *against* the <id>.
     Usage: /cs <id>
     """
-    if arg == "":
+    if id is None:
         if (
             client.area.minigame_schedule
             and not client.area.minigame_schedule.cancelled()
@@ -840,18 +816,15 @@ def ooc_cmd_cs(client, arg):
         else:
             client.send_ooc("There is no minigame running right now.")
         return
-    args = arg.split()
     try:
         target = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(args[0]), True
+            client, TargetType.ID, id, True
         )[0]
     except Exception:
         raise ArgumentError("Target not found.")
     else:
         try:
-            pta = False
-            if len(args) > 1:
-                pta = args[1] == "1"
+            pta = pta == "1"
             prev_mini = client.area.minigame
             client.area.start_debate(client, target, pta=pta)
             if prev_mini != client.area.minigame:
@@ -872,15 +845,15 @@ def ooc_cmd_cs(client, arg):
             raise ex
 
 
-def ooc_cmd_pta(client, arg):
+@command(Arg("id", int, help="target client ID"))
+def ooc_cmd_pta(client, id):
     """
     Start a one-on-one "Panic Talk Action" debate with targeted player!
     Unlike /cs, a Panic Talk Action (PTA) cannot evolve into a Scrum Debate.
     Expires in 5 minutes.
     Usage: /pta <id>
     """
-    args = arg.split()
-    ooc_cmd_cs(client, f"{args[0]} 1")
+    ooc_cmd_cs(client, f"{id} 1")
 
 
 def set_minigame_song(client, minigame="", song="", condition=0):
@@ -932,42 +905,46 @@ def set_minigame_song(client, minigame="", song="", condition=0):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_minigame_start_song(client, arg):
+@command(
+    Arg("minigame", default="", help="cs/sd/pta"),
+    Arg("song", rest=True, default="", type=tokens_str, help="song name (blank to pick)"),
+)
+def ooc_cmd_minigame_start_song(client, minigame, song):
     """
     Edit a starting song for any specific minigame. If songname is blank, it lets you choose a song from the music list to use.
     Usage: /minigame_start_song <cs/sd/pta> [songname]
     """
-    args = arg.split()
-    minigame = args[0] if len(args) > 0 else ""
-    song = " ".join(args[1:]) if len(args) > 1 else ""
     print(minigame, song)
     set_minigame_song(client, minigame, song, condition=0)
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_minigame_end_song(client, arg):
+@command(
+    Arg("minigame", default="", help="cs/sd/pta"),
+    Arg("song", rest=True, default="", type=tokens_str, help="song name (blank to pick)"),
+)
+def ooc_cmd_minigame_end_song(client, minigame, song):
     """
     Edit a ending song for any specific minigame. If songname is blank, it lets you choose a song from the music list to use.
     Usage: /minigame_end_song <cs/sd/pta> [songname]
     """
-    args = arg.split()
-    minigame = args[0] if len(args) > 0 else ""
-    song = " ".join(args[1:]) if len(args) > 1 else ""
     set_minigame_song(client, minigame, song, condition=1)
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_minigame_concede_song(client, arg):
+@command(
+    Arg("minigame", default="", help="cs/sd/pta"),
+    Arg("song", rest=True, default="", type=tokens_str, help="song name (blank to pick)"),
+)
+def ooc_cmd_minigame_concede_song(client, minigame, song):
     """
     Edit a concede song for any specific minigame. If songname is blank, it lets you choose a song from the music list to use.
     Usage: /minigame_concede_song <cs/sd/pta> [songname]
     """
-    args = arg.split()
-    minigame = args[0] if len(args) > 0 else ""
-    song = " ".join(args[1:]) if len(args) > 1 else ""
     set_minigame_song(client, minigame, song, condition=2)
 
 
+@command(Arg("arg", default="", help="not-pta (internal)"))
 def ooc_cmd_concede(client, arg):
     """
     Concede a trial minigame and withdraw from either team you're part of.
@@ -999,6 +976,7 @@ def ooc_cmd_concede(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="subtheme name"))
 def ooc_cmd_subtheme(client, arg):
     """
     Change the subtheme (DRO gamemode) for the hub.
@@ -1013,6 +991,7 @@ def ooc_cmd_subtheme(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="time of day name"))
 def ooc_cmd_time_of_day(client, arg):
     """
     Change the time of day for the hub.
@@ -1027,7 +1006,8 @@ def ooc_cmd_time_of_day(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_evidence_lists(client, arg):
+@command()
+def ooc_cmd_evidence_lists(client):
     """
     Show all evidence lists available on the server.
     Usage: /evidence_lists
@@ -1060,6 +1040,7 @@ def evidence_load(client, name, overlay = False):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="evidence list name"))
 def ooc_cmd_evidence_load(client, arg):
     """
     Allow you to load an evidence list from the server.
@@ -1072,6 +1053,7 @@ def ooc_cmd_evidence_load(client, arg):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="evidence list name"))
 def ooc_cmd_evidence_overlay(client, arg):
     """
     Allow you to load and overlay an evidence list from the server to the existing evidence.
@@ -1084,6 +1066,7 @@ def ooc_cmd_evidence_overlay(client, arg):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="evidence list name"))
 def ooc_cmd_evidence_save(client, arg):
     """
     Allow you to save evidence in a list stored in the server files!

--- a/server/commands/casing.py
+++ b/server/commands/casing.py
@@ -370,19 +370,16 @@ def ooc_cmd_cm(client, arg):
 
 # TODO: allow running this command from outside the area you're a CM of in hubs that allow multiple CMed areas
 @mod_only(area_owners=True)
-@command(Arg("arg", rest=True, default="", help="client ID(s) (blank = self)"))
-def ooc_cmd_uncm(client, arg):
+@command(Arg("ids", variadic=True, type=int, default=[], help="client ID(s) (blank = self)"))
+def ooc_cmd_uncm(client, ids):
     """
     Remove a case manager from the current area.
     Usage: /uncm <id>
     """
-    if len(arg) > 0:
-        arg = arg.split()
-    else:
-        arg = [client.id]
-    for _id in arg:
+    if not ids:
+        ids = [client.id]
+    for _id in ids:
         try:
-            _id = int(_id)
             c = client.server.client_manager.get_targets(
                 client, TargetType.ID, _id, False
             )[0]
@@ -393,7 +390,7 @@ def ooc_cmd_uncm(client, arg):
                 client.send_ooc(
                     "You cannot remove someone from CMing when they aren't a CM."
                 )
-        except (ValueError, IndexError):
+        except IndexError:
             client.send_ooc(f"{_id} does not look like a valid ID.")
         except (ClientError, ArgumentError):
             raise

--- a/server/commands/character.py
+++ b/server/commands/character.py
@@ -1014,48 +1014,43 @@ def ooc_cmd_keys_remove(client, arg):
             "Usage: /keys_remove <char> [area id(s)]. Removes the selected 'keys' from the user."
         )
 
-    mod_keys(client, arg, 2)
-
-
-@command(Arg("arg", rest=True, default="", help="target (blank = your own)"))
-def ooc_cmd_keys(client, arg):
+    mod_keys(client, arg, 2)@command(Arg("target", default="", help="target (blank = your own)"))
+def ooc_cmd_keys(client, target):
     """
     Check your own keys, or someone else's (if admin).
     Keys allow you to /lock or /unlock specific areas, OR
     area links if it's formatted like 1-5
     Usage: /keys [target_id]
     """
-    args = arg.split()
-    if len(args) < 1:
+    if not target:
         client.send_ooc(f"Your current keys are {client.keys}")
         return
     if not client.is_mod and not (client in client.area.area_manager.owners):
         raise ClientError("Only mods and GMs can check other people's keys.")
-    if len(args) == 1:
-        try:
-            if args[0].isnumeric():
-                target = client.server.client_manager.get_targets(
-                    client, TargetType.ID, int(args[0]), False
-                )
-                if target:
-                    target = target[0].char_id
-                else:
-                    if args[0] != "-1" and (int(args[0]) in client.area.area_manager.char_list):
-                        target = int(args[0])
-            else:
-                try:
-                    target = client.area.area_manager.get_char_id_by_name(arg)
-                except (ServerError):
-                    raise
-            keys = client.area.area_manager.get_character_data(
-                target, "keys", [])
-            client.send_ooc(
-                f"{client.area.area_manager.char_list[target]} current keys are {keys}"
+    try:
+        if target.isnumeric():
+            t = client.server.client_manager.get_targets(
+                client, TargetType.ID, int(target), False
             )
-        except Exception:
-            raise ArgumentError("Target not found.")
-    else:
-        raise ArgumentError("Usage: /keys [target_id].")
+            if t:
+                char_id = t[0].char_id
+            else:
+                if target != "-1" and (int(target) in client.area.area_manager.char_list):
+                    char_id = int(target)
+                else:
+                    raise ArgumentError("Target not found.")
+        else:
+            try:
+                char_id = client.area.area_manager.get_char_id_by_name(target)
+            except (ServerError):
+                raise
+        keys = client.area.area_manager.get_character_data(
+            char_id, "keys", [])
+        client.send_ooc(
+            f"{client.area.area_manager.char_list[char_id]} current keys are {keys}"
+        )
+    except Exception:
+        raise ArgumentError("Target not found.")
 
 
 @command()

--- a/server/commands/character.py
+++ b/server/commands/character.py
@@ -6,7 +6,7 @@ from server import database
 from server.constants import TargetType, derelative
 from server.exceptions import ClientError, ServerError, ArgumentError, AreaError
 
-from . import mod_only
+from . import mod_only, command, Arg, tokens_str
 
 __all__ = [
     "ooc_cmd_switch",
@@ -64,6 +64,7 @@ __all__ = [
 ]
 
 
+@command(Arg("arg", rest=True, default="", help="character download URL"))
 def ooc_cmd_set_url(client, arg):
     """
     This command sets the URL of the current character.
@@ -78,7 +79,8 @@ def ooc_cmd_set_url(client, arg):
     for c in client.area.clients:
         c.get_new_area_user_links()
 
-def ooc_cmd_get_urls(client, arg):
+@command()
+def ooc_cmd_get_urls(client):
     """
     This command returns the server's URL List.
     Usage: /get_urls
@@ -90,6 +92,7 @@ def ooc_cmd_get_urls(client, arg):
         f_server_links += f"{name}: {url} \n"
     client.send_ooc(f_server_links)
 
+@command(Arg("arg", rest=True, default="", help="character name/ID (blank = char select)"))
 def ooc_cmd_switch(client, arg):
     """
     Switch to another character. If moderator and the specified character is
@@ -118,6 +121,7 @@ def ooc_cmd_switch(client, arg):
     client.send_ooc("Character changed.")
 
 
+@command(Arg("arg", rest=True, default="", help="pos name (blank shows current)"))
 def ooc_cmd_pos(client, arg):
     """
     Set the place your character resides in the area.
@@ -134,6 +138,7 @@ def ooc_cmd_pos(client, arg):
         client.send_ooc("Position changed.")
 
 
+@command(Arg("arg", rest=True, default="", help="client ID or char name (blank checks)"))
 def ooc_cmd_pair(client, arg):
     """
     Pair with someone. Overrides client pairing choice.
@@ -169,7 +174,8 @@ def ooc_cmd_pair(client, arg):
         client.send_ooc("Pairing target not found!")
 
 
-def ooc_cmd_unpair(client, arg):
+@command()
+def ooc_cmd_unpair(client):
     """
     Stop pairing with someone. Stops overriding client pairing choice.
     Usage: /unpair
@@ -182,6 +188,7 @@ def ooc_cmd_unpair(client, arg):
         client.send_ooc("Serverside force-pairing is already disabled, check your client pairing settings!")
 
 
+@command(Arg("arg", default="", help="front/0 or behind/1 (blank toggles)"))
 def ooc_cmd_pair_order(client, arg):
     """
     Choose if you'll appear in front or behind someone when pairing. Only works when using serverside /pair
@@ -205,40 +212,34 @@ def ooc_cmd_pair_order(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_forcepos(client, arg):
+@command(
+    Arg("pos", help="pos, RANDOM or comma-separated list"),
+    Arg("targets", variadic=True, default=None, help="targets (blank = everyone)"),
+)
+def ooc_cmd_forcepos(client, pos, targets):
     """
     Set the place another character resides in the area.
     Usage: /forcepos <pos> <target>
     if <pos> = RANDOM, all the <target>s will be forced into a random pos, pulled from the area's pos_lock.
     if <pos> contains the "," symbol then it will be treated as a list of positions to randomize by.
     """
-    args = shlex.split(arg)
-
-    if len(args) < 1:
-        raise ArgumentError(
-            'Not enough arguments. Use /forcepos <pos> <target>. Target should be ID, OOC-name or char-name. Use /getarea for getting info like "[ID] char-name".'
-        )
-
-    targets = []
-
-    pos = args[0]
-    if len(args) > 1:
+    if targets is None:
+        targets = list(client.area.clients)
+    else:
+        target_text = " ".join(targets)
         targets = client.server.client_manager.get_targets(
-            client, TargetType.CHAR_NAME, " ".join(args[1:]), True
+            client, TargetType.CHAR_NAME, target_text, True
         )
-        if len(targets) == 0 and args[1].isdigit():
+        if len(targets) == 0 and targets[0].isdigit():
             targets = client.server.client_manager.get_targets(
-                client, TargetType.ID, int(args[1]), True
+                client, TargetType.ID, int(targets[0]), True
             )
         if len(targets) == 0:
             targets = client.server.client_manager.get_targets(
-                client, TargetType.OOC_NAME, " ".join(args[1:]), True
+                client, TargetType.OOC_NAME, target_text, True
             )
         if len(targets) == 0:
             raise ArgumentError("No targets found.")
-    else:
-        for c in client.area.clients:
-            targets.append(c)
 
     for t in targets:
         try:
@@ -266,27 +267,27 @@ def ooc_cmd_forcepos(client, arg):
             raise
 
 
-def ooc_cmd_force_switch(client, arg):
+@command(
+    Arg("target", help="target id or char name"),
+    Arg("char", rest=True, default="", type=tokens_str, help="character to force (blank = char select)"),
+)
+def ooc_cmd_force_switch(client, target, char):
     """
     Force another user to select another character.
     Optional [char] forces them into a specific character.
     Usage: /force_switch <id> [char]
     """
-    if not arg:
-        raise ArgumentError(
-            'Not enough arguments. Usage: /force_switch <id> [char]')
-    args = shlex.split(arg)
     try:
-        if args[0].isnumeric():
+        if target.isnumeric():
             targets = client.server.client_manager.get_targets(
-                client, TargetType.ID, int(args[0]), False
+                client, TargetType.ID, int(target), False
             )
         else:
             targets = client.server.client_manager.get_targets(
-                client, TargetType.CHAR_NAME, args[0], False
+                client, TargetType.CHAR_NAME, target, False
             )
-        for target in targets:
-            force_switch(client, target, " ".join(args[1:]))
+        for t in targets:
+            force_switch(client, t, char)
     except Exception as ex:
         raise ArgumentError(
             f"Error encountered: {ex}. Use /force_switch <target's id> [character] as a mod or area owner."
@@ -321,24 +322,19 @@ def force_switch(client, target, char=""):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_kill(client, arg):
+@command(Arg("ids", int, variadic=True, help="client ID(s)"))
+def ooc_cmd_kill(client, ids):
     """
     Force the character into spectator mode with a message that they have died.
     Usage: /kill <id(s)>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target.")
-    try:
-        targets = []
-        ids = [int(s) for s in arg.split(" ")]
-        for targ_id in ids:
-            c = client.server.client_manager.get_targets(
-                client, TargetType.ID, targ_id, False
-            )
-            if c:
-                targets = targets + c
-    except Exception:
-        raise ArgumentError("You must specify a target. Use /kill <id(s)>.")
+    targets = []
+    for targ_id in ids:
+        c = client.server.client_manager.get_targets(
+            client, TargetType.ID, targ_id, False
+        )
+        if c:
+            targets = targets + c
 
     try:
         for target in targets:
@@ -349,13 +345,12 @@ def ooc_cmd_kill(client, arg):
             f"Error encountered: {ex}. Use /kill <id(s)> as a mod or area owner."
         )
 
-def ooc_cmd_randomchar(client, arg):
+@command()
+def ooc_cmd_randomchar(client):
     """
     Select a random character.
     Usage: /randomchar
     """
-    if len(arg) != 0:
-        raise ArgumentError("This command has no arguments.")
     if len(client.charcurse) > 0:
         free_id = random.choice(client.charcurse)
     else:
@@ -371,23 +366,18 @@ def ooc_cmd_randomchar(client, arg):
 
 
 @mod_only()
-def ooc_cmd_charcurse(client, arg):
+@command(
+    Arg("target", int, help="client ID"),
+    Arg("charids", int, variadic=True, help="character IDs"),
+)
+def ooc_cmd_charcurse(client, target, charids):
     """
     Lock a user into being able to choose only from a list of characters.
     Usage: /charcurse <id> [charids...]
     """
-    if len(arg) == 0:
-        raise ArgumentError(
-            "You must specify a target (an ID) and at least one character ID. Consult /charids for the character IDs."
-        )
-    elif len(arg) == 1:
-        raise ArgumentError(
-            "You must specific at least one character ID. Consult /charids for the character IDs."
-        )
-    args = arg.split()
     try:
         targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(args[0]), False
+            client, TargetType.ID, target, False
         )
     except Exception:
         raise ArgumentError(
@@ -397,9 +387,8 @@ def ooc_cmd_charcurse(client, arg):
         for c in targets:
             log_msg = ""
             part_msg = " [" + str(c.id) + "] to"
-            for raw_cid in args[1:]:
+            for cid in charids:
                 try:
-                    cid = int(raw_cid)
                     c.charcurse.append(cid)
                     part_msg += " " + \
                         str(client.area.area_manager.char_list[cid]) + ","
@@ -407,7 +396,7 @@ def ooc_cmd_charcurse(client, arg):
                         str(client.area.area_manager.char_list[cid]) + ","
                 except:
                     ArgumentError(
-                        "" + str(raw_cid) +
+                        "" + str(cid) +
                         " does not look like a valid character ID."
                     )
             part_msg = part_msg[:-1]
@@ -423,17 +412,15 @@ def ooc_cmd_charcurse(client, arg):
 
 
 @mod_only()
-def ooc_cmd_uncharcurse(client, arg):
+@command(Arg("id", int, help="client ID"))
+def ooc_cmd_uncharcurse(client, id):
     """
     Remove the character choice restrictions from a user.
     Usage: /uncharcurse <id>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target (an ID).")
-    args = arg.split()
     try:
         targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(args[0]), False
+            client, TargetType.ID, id, False
         )
     except Exception:
         raise ArgumentError(
@@ -452,26 +439,24 @@ def ooc_cmd_uncharcurse(client, arg):
         client.send_ooc("No targets found.")
 
 
-def ooc_cmd_charids(client, arg):
+@command()
+def ooc_cmd_charids(client):
     """
     Show character IDs corresponding to each character name.
     Usage: /charids
     """
-    if len(arg) != 0:
-        raise ArgumentError("This command doesn't take any arguments")
     msg = "Here is a list of all available characters on the server:"
     for c in range(0, len(client.area.area_manager.char_list)):
         msg += "\n[" + str(c) + "] " + client.area.area_manager.char_list[c]
     client.send_ooc(msg)
 
 
-def ooc_cmd_reload(client, arg):
+@command()
+def ooc_cmd_reload(client):
     """
     Reload a character to its default position and state.
     Usage: /reload
     """
-    if len(arg) != 0:
-        raise ArgumentError("This command doesn't take any arguments")
     try:
         client.reload_character()
     except ClientError:
@@ -480,24 +465,19 @@ def ooc_cmd_reload(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_blind(client, arg):
+@command(Arg("ids", int, variadic=True, help="client ID(s)"))
+def ooc_cmd_blind(client, ids):
     """
     Blind the targeted player(s) from being able to see or talk IC.
     Usage: /blind <id(s)>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target.")
-    try:
-        targets = []
-        ids = [int(s) for s in arg.split(" ")]
-        for targ_id in ids:
-            c = client.server.client_manager.get_targets(
-                client, TargetType.ID, targ_id, False
-            )
-            if c:
-                targets = targets + c
-    except Exception:
-        raise ArgumentError("You must specify a target. Use /blind <id>.")
+    targets = []
+    for targ_id in ids:
+        c = client.server.client_manager.get_targets(
+            client, TargetType.ID, targ_id, False
+        )
+        if c:
+            targets = targets + c
 
     if targets:
         for c in targets:
@@ -513,24 +493,19 @@ def ooc_cmd_blind(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_unblind(client, arg):
+@command(Arg("ids", int, variadic=True, help="client ID(s)"))
+def ooc_cmd_unblind(client, ids):
     """
     Undo effects of the /blind command.
     Usage: /unblind <id(s)>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target.")
-    try:
-        targets = []
-        ids = [int(s) for s in arg.split(" ")]
-        for targ_id in ids:
-            c = client.server.client_manager.get_targets(
-                client, TargetType.ID, targ_id, False
-            )
-            if c:
-                targets = targets + c
-    except Exception:
-        raise ArgumentError("You must specify a target. Use /unblind <id>.")
+    targets = []
+    for targ_id in ids:
+        c = client.server.client_manager.get_targets(
+            client, TargetType.ID, targ_id, False
+        )
+        if c:
+            targets = targets + c
 
     if targets:
         for c in targets:
@@ -543,35 +518,38 @@ def ooc_cmd_unblind(client, arg):
         raise ArgumentError("No targets found.")
 
 
-def ooc_cmd_player_move_delay(client, arg):
+@command(
+    Arg("target", default="", help="target (blank = yourself)"),
+    Arg("delay", int, default=None, help="delay in seconds (-1800..1800)"),
+)
+def ooc_cmd_player_move_delay(client, target, delay):
     """
     Set the player's move delay to a value in seconds. Can be negative.
     Delay must be from -1800 to 1800 in seconds or empty to check.
     Usage: /player_move_delay <id> [delay]
     """
-    args = shlex.split(arg)
     try:
-        if len(args) > 0 and (
+        if target and (
             client.is_mod or client in client.area.area_manager.owners
         ):
             # Try to find by char name first
             targets = client.server.client_manager.get_targets(
-                client, TargetType.CHAR_NAME, args[0]
+                client, TargetType.CHAR_NAME, target
             )
             # If that doesn't work, find by client ID
-            if len(targets) == 0 and args[0].isdigit():
+            if len(targets) == 0 and target.isdigit():
                 targets = client.server.client_manager.get_targets(
-                    client, TargetType.ID, int(args[0])
+                    client, TargetType.ID, int(target)
                 )
             # If that doesn't work, find by OOC Name
             if len(targets) == 0:
                 targets = client.server.client_manager.get_targets(
-                    client, TargetType.OOC_NAME, args[0]
+                    client, TargetType.OOC_NAME, target
                 )
             c = targets[0]
-            if len(args) > 1:
+            if delay is not None:
                 move_delay = min(
-                    1800, max(-1800, int(args[1]))
+                    1800, max(-1800, delay)
                 )  # Move delay is limited between -1800 and 1800
                 c.move_delay = move_delay
                 client.send_ooc(
@@ -581,8 +559,6 @@ def ooc_cmd_player_move_delay(client, arg):
                     f"Move delay for {c.char_name} is {c.move_delay}.")
         else:
             client.send_ooc(f"Your current move delay is {client.move_delay}.")
-    except ValueError:
-        raise ArgumentError("Delay must be an integer between -1800 and 1800.")
     except IndexError:
         raise ArgumentError(
             "Target client not found. Use /player_move_delay <id> [delay]."
@@ -592,33 +568,25 @@ def ooc_cmd_player_move_delay(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_player_hide(client, arg):
+@command(Arg("ids", variadic=True, help="client ID(s) or *"))
+def ooc_cmd_player_hide(client, ids):
     """
     Hide player(s) from /getarea and playercounts.
     If <id> is *, it will hide everyone in the area excluding yourself and CMs.
     Usage: /player_hide <id(s)>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target.")
-    args = arg.split()
-    if args[0] == "*":
+    if ids[0] == "*":
         targets = [
             c for c in client.area.clients if c != client and c != client.area.owners
         ]
     else:
-        try:
-            targets = []
-            ids = [int(s) for s in args]
-            for targ_id in ids:
-                c = client.server.client_manager.get_targets(
-                    client, TargetType.ID, targ_id, False
-                )
-                if c:
-                    targets = targets + c
-        except Exception:
-            raise ArgumentError(
-                "You must specify a target. Use /player_unhide <id> [id(s)]."
+        targets = []
+        for targ_id in ids:
+            c = client.server.client_manager.get_targets(
+                client, TargetType.ID, int(targ_id), False
             )
+            if c:
+                targets = targets + c
     if targets:
         for c in targets:
             if c.hidden:
@@ -633,33 +601,25 @@ def ooc_cmd_player_hide(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_player_unhide(client, arg):
+@command(Arg("ids", variadic=True, help="client ID(s) or *"))
+def ooc_cmd_player_unhide(client, ids):
     """
     Unhide player(s) from /getarea and playercounts.
     If <id> is *, it will unhide everyone in the area excluding yourself and CMs.
     Usage: /player_unhide <id(s)>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target.")
-    args = arg.split()
-    if args[0] == "*":
+    if ids[0] == "*":
         targets = [
             c for c in client.area.clients if c != client and c != client.area.owners
         ]
     else:
-        try:
-            targets = []
-            ids = [int(s) for s in args]
-            for targ_id in ids:
-                c = client.server.client_manager.get_targets(
-                    client, TargetType.ID, targ_id, False
-                )
-                if c:
-                    targets = targets + c
-        except Exception:
-            raise ArgumentError(
-                "You must specify a target. Use /player_unhide <id> [id(s)]."
+        targets = []
+        for targ_id in ids:
+            c = client.server.client_manager.get_targets(
+                client, TargetType.ID, int(targ_id), False
             )
+            if c:
+                targets = targets + c
     if targets:
         for c in targets:
             if not c.hidden:
@@ -673,6 +633,7 @@ def ooc_cmd_player_unhide(client, arg):
         client.send_ooc("No targets found.")
 
 
+@command(Arg("arg", rest=True, default="", help="evidence name or id"))
 def ooc_cmd_hide(client, arg):
     """
     Try to hide in the targeted evidence name or ID.
@@ -693,7 +654,8 @@ def ooc_cmd_hide(client, arg):
         raise
 
 
-def ooc_cmd_unhide(client, arg):
+@command()
+def ooc_cmd_unhide(client):
     """
     Stop hiding.
     Usage: /unhide
@@ -702,6 +664,7 @@ def ooc_cmd_unhide(client, arg):
     client.area.broadcast_area_list(client)
 
 
+@command(Arg("arg", rest=True, default="", help="target (blank = yourself)"))
 def ooc_cmd_sneak(client, arg):
     """
     Begin sneaking a.k.a. hide your area moving messages from the OOC.
@@ -731,6 +694,7 @@ def ooc_cmd_sneak(client, arg):
                 f"Error encountered: {ex}. Use /sneak [id]")
 
 
+@command(Arg("arg", rest=True, default="", help="target (blank = yourself)"))
 def ooc_cmd_unsneak(client, arg):
     """
     Stop sneaking a.k.a. show your area moving messages in the OOC.
@@ -771,24 +735,19 @@ def force_unsneak(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_freeze(client, arg):
+@command(Arg("ids", int, variadic=True, help="client ID(s)"))
+def ooc_cmd_freeze(client, ids):
     """
     Freeze targeted player(s) from being able to move between areas.
     Usage: /freeze <id(s)>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target.")
-    try:
-        targets = []
-        ids = [int(s) for s in arg.split(" ")]
-        for targ_id in ids:
-            c = client.server.client_manager.get_targets(
-                client, TargetType.ID, targ_id, False
-            )
-            if c:
-                targets = targets + c
-    except Exception:
-        raise ArgumentError("You must specify a target. Use /freeze <id>.")
+    targets = []
+    for targ_id in ids:
+        c = client.server.client_manager.get_targets(
+            client, TargetType.ID, targ_id, False
+        )
+        if c:
+            targets = targets + c
 
     if targets:
         for c in targets:
@@ -804,24 +763,19 @@ def ooc_cmd_freeze(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_unfreeze(client, arg):
+@command(Arg("ids", int, variadic=True, help="client ID(s)"))
+def ooc_cmd_unfreeze(client, ids):
     """
     Undo effects of the /freeze command.
     Usage: /unfreeze <id(s)>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target.")
-    try:
-        targets = []
-        ids = [int(s) for s in arg.split(" ")]
-        for targ_id in ids:
-            c = client.server.client_manager.get_targets(
-                client, TargetType.ID, targ_id, False
-            )
-            if c:
-                targets = targets + c
-    except Exception:
-        raise ArgumentError("You must specify a target. Use /unfreeze <id>.")
+    targets = []
+    for targ_id in ids:
+        c = client.server.client_manager.get_targets(
+            client, TargetType.ID, targ_id, False
+        )
+        if c:
+            targets = targets + c
 
     if targets:
         for c in targets:
@@ -834,17 +788,15 @@ def ooc_cmd_unfreeze(client, arg):
         raise ArgumentError("No targets found.")
 
 
-def ooc_cmd_listen_pos(client, arg):
+@command(Arg("pos", variadic=True, default=None, help="pos(s) (blank = your own)"))
+def ooc_cmd_listen_pos(client, pos):
     """
     Start only listening to your currently occupied pos.
     All messages outside of that pos will be reflected in the OOC.
     Optional argument is a list of positions you want to listen to.
     Usage: /listen_pos [pos(s)]
     """
-    args = arg.split()
-    value = "self"
-    if len(args) > 0:
-        value = args
+    value = "self" if pos is None else pos
 
     client.listen_pos = value
     if value == "self":
@@ -855,7 +807,8 @@ def ooc_cmd_listen_pos(client, arg):
     client.send_ooc(f"You are {value}. Use /unlisten_pos to stop listening.")
 
 
-def ooc_cmd_unlisten_pos(client, arg):
+@command()
+def ooc_cmd_unlisten_pos(client):
     """
     Undo the effects of /listen_pos command so you stop listening to the position(s).
     Usage: /unlisten_pos
@@ -869,6 +822,7 @@ def ooc_cmd_unlisten_pos(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="save path"))
 def ooc_cmd_save_character_data(client, arg):
     """
     Save the move_delay, keys, etc. for characters into a file in the storage/character_data/ folder.
@@ -888,6 +842,7 @@ def ooc_cmd_save_character_data(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="load path"))
 def ooc_cmd_load_character_data(client, arg):
     """
     Load the move_delay, keys, etc. for characters from a file in the storage/character_data/ folder.
@@ -916,19 +871,19 @@ def _resolve_char_arg(hub, text):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_get_char_data(client, arg):
+@command(
+    Arg("target", help="char id or folder name"),
+    Arg("key", default="", help="data key (blank = all)"),
+)
+def ooc_cmd_get_char_data(client, target, key):
     """
     View the custom data saved for a character (or a single key of it).
     Usage: /get_char_data <char id|folder> [key]
     """
-    args = arg.split()
-    if len(args) < 1:
-        raise ArgumentError("Please provide a character id or folder name.")
     hub = client.area.area_manager
-    folder = hub.char_list[_resolve_char_arg(hub, args[0])]
+    folder = hub.char_list[_resolve_char_arg(hub, target)]
     data = hub.character_data.get(folder, {})
-    if len(args) >= 2:
-        key = args[1]
+    if key:
         if key not in data:
             raise ArgumentError(f"Character '{folder}' has no data key '{key}'.")
         client.send_ooc(f"{folder}.{key} = {data[key]}")
@@ -941,26 +896,26 @@ def ooc_cmd_get_char_data(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_set_char_data(client, arg):
+@command(
+    Arg("target", help="char id or folder name"),
+    Arg("key", help="data key"),
+    Arg("value", rest=True, default="", help="new value (blank removes the key)"),
+)
+def ooc_cmd_set_char_data(client, target, key, value):
     """
     Set (or clear) a custom data key for a character; omit the value to remove the key.
     Usage: /set_char_data <char id|folder> <key> [value...]
     """
-    parts = arg.split(None, 2)
-    if len(parts) < 2:
-        raise ArgumentError("Usage: /set_char_data <char id|folder> <key> [value...]")
     hub = client.area.area_manager
-    folder = hub.char_list[_resolve_char_arg(hub, parts[0])]
-    key = parts[1]
+    folder = hub.char_list[_resolve_char_arg(hub, target)]
     data = hub.character_data.setdefault(folder, {})
-    if len(parts) < 3 or not parts[2].strip():
+    if not value.strip():
         if key in data:
             del data[key]
             client.send_ooc(f"Removed '{folder}.{key}'.")
         else:
             client.send_ooc(f"Character '{folder}' has no data key '{key}'.")
     else:
-        value = parts[2]
         hub.set_character_data(folder, key, value)
         client.send_ooc(f"Set '{folder}.{key}' = {value}.")
     hub.save_character_data()
@@ -1022,6 +977,7 @@ def mod_keys(client, arg, mod=0):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="<char> [key(s)]"))
 def ooc_cmd_keys_set(client, arg):
     """
     Sets the keys of the target client/character folder/character id to the key(s). Keys must be a number like 5 or a link eg. 1-5.
@@ -1034,6 +990,7 @@ def ooc_cmd_keys_set(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="<char> [key(s)]"))
 def ooc_cmd_keys_add(client, arg):
     """
     Adds the keys of the target client/character folder/character id to the key(s). Keys must be a number like 5 or a link eg. 1-5.
@@ -1046,6 +1003,7 @@ def ooc_cmd_keys_add(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="<char> [key(s)]"))
 def ooc_cmd_keys_remove(client, arg):
     """
     Remvove the keys of the target client/character folder/character id from the key(s). Keys must be a number like 5 or a link eg. 1-5.
@@ -1059,6 +1017,7 @@ def ooc_cmd_keys_remove(client, arg):
     mod_keys(client, arg, 2)
 
 
+@command(Arg("arg", rest=True, default="", help="target (blank = your own)"))
 def ooc_cmd_keys(client, arg):
     """
     Check your own keys, or someone else's (if admin).
@@ -1099,14 +1058,13 @@ def ooc_cmd_keys(client, arg):
         raise ArgumentError("Usage: /keys [target_id].")
 
 
-def ooc_cmd_kms(client, arg):
+@command()
+def ooc_cmd_kms(client):
     """
     Stands for Kick MySelf - Kick other instances of the client opened by you.
     Useful if you lose connection and the old client is ghosting.
     Usage: /kms
     """
-    if arg != "":
-        raise ArgumentError("This command takes no arguments!")
     for target in client.server.client_manager.get_multiclients(
         client.ipid, client.hdid
     ):
@@ -1116,6 +1074,7 @@ def ooc_cmd_kms(client, arg):
     database.log_misc("kms", client)
 
 
+@command(Arg("arg", rest=True, default="", help="description or ID (blank shows yours)"))
 def ooc_cmd_chardesc(client, arg):
     """
     Look at your own character description if no arugments are provided.
@@ -1166,7 +1125,8 @@ def ooc_cmd_chardesc(client, arg):
         database.log_area("chardesc.change", client, client.area, message=arg)
 
 
-def ooc_cmd_chardesc_clear(client, arg):
+@command()
+def ooc_cmd_chardesc_clear(client):
     """
     Clear your chardesc.
     Usage: /chardesc_clear
@@ -1185,33 +1145,31 @@ def ooc_cmd_chardesc_clear(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_chardesc_set(client, arg):
+@command(
+    Arg("target", help="client ID, char id or char name"),
+    Arg("desc", rest=True, default="", help="new description (blank clears)"),
+)
+def ooc_cmd_chardesc_set(client, target, desc):
     """
     Set someone else's character description to desc or clear it.
     Usage: /chardesc_set <id> [desc]
     """
-    args = arg.split(" ")
-    if len(args) < 1:
-        raise ArgumentError(
-            "Not enough arguments. Usage: /chardesc_set <id> [desc]")
     try:
-        if args[0].isnumeric():
-            target = client.server.client_manager.get_targets(
-                client, TargetType.ID, int(args[0]), False
+        if target.isnumeric():
+            targets = client.server.client_manager.get_targets(
+                client, TargetType.ID, int(target), False
             )
-            if target:
-                target = target[0].char_id
+            if targets:
+                target = targets[0].char_id
             else:
-                if args[0] != "-1" and (int(args[0]) in client.area.area_manager.char_list):
-                    target = int(args[0])
+                if target != "-1" and (int(target) in client.area.area_manager.char_list):
+                    target = int(target)
         else:
             try:
-                target = client.area.area_manager.get_char_id_by_name(arg)
+                target = client.area.area_manager.get_char_id_by_name(target)
             except (ServerError):
                 raise
-        desc = ""
-        if len(args) > 1:
-            desc = " ".join(args[1:]).strip()
+        desc = desc.strip()
         client.area.area_manager.set_character_data(target, "desc", desc)
         target = client.area.area_manager.char_list[target]
         client.send_ooc(f"📜{target} Description: {desc}")
@@ -1225,6 +1183,7 @@ def ooc_cmd_chardesc_set(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="client ID, char id or char name"))
 def ooc_cmd_chardesc_get(client, arg):
     """
     Get someone else's character description.
@@ -1255,26 +1214,15 @@ def ooc_cmd_chardesc_get(client, arg):
         raise ArgumentError("Target not found.")
 
 
-def ooc_cmd_narrate(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_narrate(client, tog):
     """
     Speak as a Narrator for your next emote.
     If using 2.9.1, when you speak IC only the chat box will be affected, making you "narrate" over the current visuals.
     tog can be `on`, `off` or empty.
     Usage: /narrate [tog]
     """
-    if len(arg.split()) > 1:
-        raise ArgumentError(
-            "This command can only take one argument ('on' or 'off') or no arguments at all!"
-        )
-    if arg:
-        if arg == "on":
-            client.narrator = True
-        elif arg == "off":
-            client.narrator = False
-        else:
-            raise ArgumentError("Invalid argument: {}".format(arg))
-    else:
-        client.narrator = not client.narrator
+    client.narrator = not client.narrator if tog is None else tog
     if client.blankpost is True:
         client.blankpost = False
         client.send_ooc(
@@ -1286,25 +1234,14 @@ def ooc_cmd_narrate(client, arg):
     client.send_ooc(f"You will {stat}.")
 
 
-def ooc_cmd_blankpost(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_blankpost(client, tog):
     """
     Use a blank image for your next emote (base/misc/blank.png, will be a missingno if you don't have it)
     tog can be `on`, `off` or empty.
     Usage: /blankpost [tog]
     """
-    if len(arg.split()) > 1:
-        raise ArgumentError(
-            "This command can only take one argument ('on' or 'off') or no arguments at all!"
-        )
-    if arg:
-        if arg == "on":
-            client.blankpost = True
-        elif arg == "off":
-            client.blankpost = False
-        else:
-            raise ArgumentError("Invalid argument: {}".format(arg))
-    else:
-        client.blankpost = not client.blankpost
+    client.blankpost = not client.blankpost if tog is None else tog
     if client.narrator is True:
         client.narrator = False
         client.send_ooc(
@@ -1316,26 +1253,15 @@ def ooc_cmd_blankpost(client, arg):
     client.send_ooc(f"You will {stat}.")
 
 
-def ooc_cmd_firstperson(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_firstperson(client, tog):
     """
     Speak as a Narrator for your next emote, but only to yourself. Everyone else will see the emote you used.
     If using 2.9.1, when you speak IC only the chat box will be affected.
     tog can be `on`, `off` or empty.
     Usage: /firstperson [tog]
     """
-    if len(arg.split()) > 1:
-        raise ArgumentError(
-            "This command can only take one argument ('on' or 'off') or no arguments at all!"
-        )
-    if arg:
-        if arg == "on":
-            client.firstperson = True
-        elif arg == "off":
-            client.firstperson = False
-        else:
-            raise ArgumentError("Invalid argument: {}".format(arg))
-    else:
-        client.firstperson = not client.firstperson
+    client.firstperson = not client.firstperson if tog is None else tog
     if client.narrator is True:
         client.narrator = False
         client.send_ooc(
@@ -1347,6 +1273,7 @@ def ooc_cmd_firstperson(client, arg):
     client.send_ooc(f"You will {stat}.")
 
 
+@command(Arg("arg", rest=True, default="", help="showname (blank resets)"))
 def ooc_cmd_showname(client, arg):
     """
     Set your own showname similar to the showname box in the client.
@@ -1377,7 +1304,8 @@ def ooc_cmd_showname(client, arg):
         client.area.broadcast_player_list()
 
 
-def ooc_cmd_charlists(client, arg):
+@command()
+def ooc_cmd_charlists(client):
     """
     Displays all the available charlists.
     Usage: /charlists
@@ -1392,6 +1320,7 @@ def ooc_cmd_charlists(client, arg):
     client.send_ooc(text)
 
 
+@command(Arg("arg", rest=True, default="", help="client ID or *"))
 def ooc_cmd_webfiles(client, arg):
     """
     Gives a link to download each characters files from webAO
@@ -1421,6 +1350,7 @@ def ooc_cmd_webfiles(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="charlist path (blank resets)"))
 def ooc_cmd_charlist(client, arg):
     """
     Load a character list. /charlists to see available character lists.
@@ -1439,6 +1369,7 @@ def ooc_cmd_charlist(client, arg):
         client.send_ooc("File not found!")
 
 
+@command(Arg("arg", rest=True, default="", help="client ID or char name (blank checks)"))
 def ooc_cmd_triple_pair(client, arg):
     """
     Triple Pair with someone.
@@ -1489,6 +1420,7 @@ def get_latest_area(client, char_id: int):
     return target_area
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="client ID or char name (blank = yours)"))
 def ooc_cmd_get_latest_area(client, arg):
     """
     Get a character's latest occupied area. Lobby area is always excluded.
@@ -1516,6 +1448,7 @@ def ooc_cmd_get_latest_area(client, arg):
         client.send_ooc(f"Area not found!")
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="client ID or char name (blank = yours)"))
 def ooc_cmd_kick_to_latest_area(client, arg):
     """
     Kick the occupied character in current area to their latest occupied area.
@@ -1562,6 +1495,7 @@ def ooc_cmd_kick_to_latest_area(client, arg):
             raise
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="<cid|charname> [area_id]"))
 def ooc_cmd_set_latest_area(client, arg):
     """
     Set a character's latest occupied area. Lobby area is always excluded.

--- a/server/commands/fun.py
+++ b/server/commands/fun.py
@@ -1,8 +1,7 @@
 from server import database
 from server.constants import TargetType
-from server.exceptions import ClientError, ArgumentError
 
-from . import mod_only
+from . import mod_only, command, Arg
 
 __all__ = [
     "ooc_cmd_disemvowel",
@@ -17,19 +16,15 @@ __all__ = [
 
 
 @mod_only()
-def ooc_cmd_disemvowel(client, arg):
+@command(Arg("id", int, help="client ID"))
+def ooc_cmd_disemvowel(client, id):
     """
     Remove all vowels from a user's IC chat.
     Usage: /disemvowel <id>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target.")
-    try:
-        targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(arg), False
-        )
-    except Exception:
-        raise ArgumentError("You must specify a target. Use /disemvowel <id>.")
+    targets = client.server.client_manager.get_targets(
+        client, TargetType.ID, id, False
+    )
     if targets:
         for c in targets:
             database.log_area("disemvowel", client, client.area, target=c)
@@ -40,20 +35,15 @@ def ooc_cmd_disemvowel(client, arg):
 
 
 @mod_only()
-def ooc_cmd_undisemvowel(client, arg):
+@command(Arg("id", int, help="client ID"))
+def ooc_cmd_undisemvowel(client, id):
     """
     Give back the freedom of vowels to a user.
     Usage: /undisemvowel <id>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target.")
-    try:
-        targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(arg), False
-        )
-    except Exception:
-        raise ArgumentError(
-            "You must specify a target. Use /undisemvowel <id>.")
+    targets = client.server.client_manager.get_targets(
+        client, TargetType.ID, id, False
+    )
     if targets:
         for c in targets:
             database.log_area("undisemvowel", client, client.area, target=c)
@@ -64,19 +54,15 @@ def ooc_cmd_undisemvowel(client, arg):
 
 
 @mod_only()
-def ooc_cmd_shake(client, arg):
+@command(Arg("id", int, help="client ID"))
+def ooc_cmd_shake(client, id):
     """
     Scramble the words in a user's IC chat.
     Usage: /shake <id>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target.")
-    try:
-        targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(arg), False
-        )
-    except Exception:
-        raise ArgumentError("You must specify a target. Use /shake <id>.")
+    targets = client.server.client_manager.get_targets(
+        client, TargetType.ID, id, False
+    )
     if targets:
         for c in targets:
             database.log_area("shake", client, client.area, target=c)
@@ -87,19 +73,15 @@ def ooc_cmd_shake(client, arg):
 
 
 @mod_only()
-def ooc_cmd_unshake(client, arg):
+@command(Arg("id", int, help="client ID"))
+def ooc_cmd_unshake(client, id):
     """
     Give back the freedom of coherent grammar to a user.
     Usage: /unshake <id>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target.")
-    try:
-        targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(arg), False
-        )
-    except Exception:
-        raise ArgumentError("You must specify a target. Use /unshake <id>.")
+    targets = client.server.client_manager.get_targets(
+        client, TargetType.ID, id, False
+    )
     if targets:
         for c in targets:
             database.log_area("unshake", client, client.area, target=c)
@@ -109,12 +91,13 @@ def ooc_cmd_unshake(client, arg):
         client.send_ooc("No targets found.")
 
 
-def ooc_cmd_rainbow(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_rainbow(client, tog):
     """
     rainbow text is back baybee
     Usage: /rainbow [true/false]
     """
-    client.rainbow = not client.rainbow
+    client.rainbow = not client.rainbow if tog is None else tog
     toggle = "now" if client.rainbow else "no longer"
     client.send_ooc(
         f"You will {toggle} have rainbowtext."
@@ -122,19 +105,15 @@ def ooc_cmd_rainbow(client, arg):
 
 
 @mod_only()
-def ooc_cmd_medieval(client, arg):
+@command(Arg("id", int, help="client ID"))
+def ooc_cmd_medieval(client, id):
     """
     Transform a user's IC chat into Ye Olde English.
     Usage: /medieval <id>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target.")
-    try:
-        targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(arg), False
-        )
-    except Exception:
-        raise ArgumentError("You must specify a target. Use /medieval <id>.")
+    targets = client.server.client_manager.get_targets(
+        client, TargetType.ID, id, False
+    )
     if targets:
         for c in targets:
             if c.medieval:
@@ -149,19 +128,15 @@ def ooc_cmd_medieval(client, arg):
 
 
 @mod_only()
-def ooc_cmd_unmedieval(client, arg):
+@command(Arg("id", int, help="client ID"))
+def ooc_cmd_unmedieval(client, id):
     """
     Return a user's IC chat to normal speech.
     Usage: /unmedieval <id>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target.")
-    try:
-        targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(arg), False
-        )
-    except Exception:
-        raise ArgumentError("You must specify a target. Use /unmedieval <id>.")
+    targets = client.server.client_manager.get_targets(
+        client, TargetType.ID, id, False
+    )
     if targets:
         for c in targets:
             if not c.medieval:
@@ -176,23 +151,12 @@ def ooc_cmd_unmedieval(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_medieval_mode(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_medieval_mode(client, tog):
     """
     Toggle medieval mode for this area. All IC messages will be transformed into Ye Olde English.
     Usage: /medieval_mode [on/off]
     """
-    if len(arg.split()) > 1:
-        raise ArgumentError(
-            "This command can only take one argument ('on' or 'off') or no arguments at all!"
-        )
-    if arg:
-        if arg == "on":
-            client.area.medieval_mode = True
-        elif arg == "off":
-            client.area.medieval_mode = False
-        else:
-            raise ArgumentError("Invalid argument: {}".format(arg))
-    else:
-        client.area.medieval_mode = not client.area.medieval_mode
+    client.area.medieval_mode = not client.area.medieval_mode if tog is None else tog
     stat = "now" if client.area.medieval_mode else "no longer"
-    client.area.broadcast_ooc(f"This area is {stat} in Medieval Mode. Hark!")
+    client.area.broadcast_ooc(f"This area is {stat} in Medieval Mode. Hark!")

--- a/server/commands/hubs.py
+++ b/server/commands/hubs.py
@@ -472,8 +472,11 @@ def ooc_cmd_area_switch(client, id1, id2):
 
 
 @mod_only(area_owners=True)
-@command(Arg("arg", rest=True, default="", help="[pref] [on/true/off/false]"))
-def ooc_cmd_area_pref(client, arg):
+@command(
+    Arg("pref", default="", help="preference name"),
+    Arg("value", default="", help="on/true/off/false"),
+)
+def ooc_cmd_area_pref(client, pref, value):
     """
     Toggle a preference on/off for an area.
     Leave pref out to see available prefs.
@@ -485,25 +488,19 @@ def ooc_cmd_area_pref(client, arg):
     # drift apart.
     cm_allowed = AREA_PREF_CM_ALLOWED
 
-    if len(arg) == 0:
+    if not pref:
         msg = "Current preferences:"
         for attri in client.area.__dict__.keys():
-            value = getattr(client.area, attri)
-            if not (type(value) is bool):
+            area_val = getattr(client.area, attri)
+            if not (type(area_val) is bool):
                 continue
             mod = "[gm] " if not (attri in cm_allowed) else ""
-            msg += f"\n* {mod}{attri}={value}"
+            msg += f"\n* {mod}{attri}={area_val}"
         client.send_ooc(msg)
         return
 
-    args = arg.split()
-    if len(args) > 2:
-        raise ArgumentError(
-            "Usage: /area_pref | /area_pref <pref> | /area_pref <pref> <on|off>"
-        )
-
     try:
-        cmd = args[0].lower()
+        cmd = pref.lower()
         attri = getattr(client.area, cmd)
         if not (type(attri) is bool):
             raise ArgumentError("Preference is not a boolean.")
@@ -514,13 +511,13 @@ def ooc_cmd_area_pref(client, arg):
         ):
             raise ClientError("You need to be a GM to modify this preference.")
         tog = not attri
-        if len(args) > 1:
-            if args[1].lower() in ("1", "on", "true"):
+        if value:
+            if value.lower() in ("1", "on", "true"):
                 tog = True
-            elif args[1].lower() in ("0", "off", "false"):
+            elif value.lower() in ("0", "off", "false"):
                 tog = False
             else:
-                raise ArgumentError("Invalid argument: {}".format(arg))
+                raise ArgumentError(f"Invalid argument: {value}")
         client.send_ooc(f"Setting preference {cmd} to {tog}...")
         setattr(client.area, cmd, tog)
         database.log_area(
@@ -992,20 +989,17 @@ def ooc_cmd_gmpanel(client):
 
 
 @mod_only(hub_owners=True)
-@command(Arg("arg", rest=True, default="", help="client ID(s) (blank = self)"))
-def ooc_cmd_ungm(client, arg):
+@command(Arg("ids", variadic=True, type=int, default=[], help="client ID(s) (blank = self)"))
+def ooc_cmd_ungm(client, ids):
     """
     Remove a game master from the current Hub.
     If blank, demote yourself from being a GM.
     Usage: /ungm <id>
     """
-    if len(arg) > 0:
-        arg = arg.split()
-    else:
-        arg = [client.id]
-    for _id in arg:
+    if not ids:
+        ids = [client.id]
+    for _id in ids:
         try:
-            _id = int(_id)
             c = client.server.client_manager.get_targets(
                 client, TargetType.ID, _id, False
             )[0]
@@ -1016,8 +1010,8 @@ def ooc_cmd_ungm(client, arg):
                 client.send_ooc(
                     "You cannot remove someone from GMing when they aren't a GM."
                 )
-        except (ValueError, IndexError):
-            client.send_ooc(f"{id} does not look like a valid ID.")
+        except IndexError:
+            client.send_ooc(f"{_id} does not look like a valid ID.")
         except (ClientError, ArgumentError):
             raise
 

--- a/server/commands/hubs.py
+++ b/server/commands/hubs.py
@@ -9,7 +9,7 @@ from server.exceptions import ClientError, ArgumentError, AreaError
 from server.constants import dezalgo
 from server.schema.area_fields import AREA_PREF_CM_ALLOWED
 
-from . import mod_only
+from . import mod_only, command, Arg
 
 __all__ = [
     # Navigation
@@ -54,6 +54,7 @@ __all__ = [
 ]
 
 
+@command(Arg("arg", rest=True, default="", help="hub id/name (blank lists)"))
 def ooc_cmd_hub(client, arg):
     """
     List hubs, or go to another hub.
@@ -100,6 +101,7 @@ def ooc_cmd_hub(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="<name> <read_only>"))
 def ooc_cmd_save_hub(client, arg):
     """
     Save the current Hub in the server's storage/hubs/<name>.yaml file.
@@ -166,6 +168,7 @@ def ooc_cmd_save_hub(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="hub file name"))
 def ooc_cmd_load_hub(client, arg):
     """
     Load Hub data from the server's storage/hubs/<name>.yaml file.
@@ -208,6 +211,7 @@ def ooc_cmd_load_hub(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="hub file name"))
 def ooc_cmd_overlay_hub(client, arg):
     """
     Overlay Hub data from the server's `storage/hubs/<name>.yaml` file on top of the current hub, only applying properties defined in that yaml.
@@ -244,7 +248,8 @@ def ooc_cmd_overlay_hub(client, arg):
         client.send_ooc("Success, sending ARUP and refreshing music...")
 
 
-def ooc_cmd_list_hubs(client, arg):
+@command()
+def ooc_cmd_list_hubs(client):
     """
     Show all the available hubs for loading in the storage/hubs/ folder.
     Usage: /list_hubs
@@ -280,13 +285,12 @@ def ooc_cmd_list_hubs(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_clear_hub(client, arg):
+@command()
+def ooc_cmd_clear_hub(client):
     """
     Clear the current hub and reset it to its default state.
     Usage: /clear_hub
     """
-    if arg != "":
-        raise ArgumentError("This command takes no arguments!")
     try:
         client.server.hub_manager.load(hub_id=client.area.area_manager.id)
         client.area.area_manager.broadcast_ooc("Hub clearing initiated...")
@@ -298,6 +302,7 @@ def ooc_cmd_clear_hub(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="new hub name"))
 def ooc_cmd_rename_hub(client, arg):
     """
     Rename the hub you are currently in to <name>.
@@ -314,6 +319,7 @@ def ooc_cmd_rename_hub(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="area name (optional)"))
 def ooc_cmd_area_create(client, arg):
     """
     Create a new area.
@@ -337,56 +343,47 @@ def ooc_cmd_area_create(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_area_remove(client, arg):
+@command(Arg("id", int, help="area ID"))
+def ooc_cmd_area_remove(client, id):
     """
     Remove specified area by Area ID.
     Usage: /area_remove <id>
     """
-    args = arg.split()
-
-    if len(args) == 1:
-        try:
-            area = client.area.area_manager.get_area_by_id(int(args[0]))
-            name = area.name
-            client.area.area_manager.remove_area(area)
-            client.area.area_manager.broadcast_area_list()
-            client.send_ooc(f"Area {name} removed!")
-        except ValueError:
-            raise ArgumentError("Area ID must be a number.")
-        except (AreaError, ClientError):
-            raise
-    else:
-        raise ArgumentError(
-            "Invalid number of arguments. Use /area_remove <aid>.")
+    try:
+        area = client.area.area_manager.get_area_by_id(id)
+        name = area.name
+        client.area.area_manager.remove_area(area)
+        client.area.area_manager.broadcast_area_list()
+        client.send_ooc(f"Area {name} removed!")
+    except ValueError:
+        raise ArgumentError("Area ID must be a number.")
+    except (AreaError, ClientError):
+        raise
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_area_duplicate(client, arg):
+@command(Arg("id", int, help="area ID"))
+def ooc_cmd_area_duplicate(client, id):
     """
     Duplicate an area, copying all of its properties and evidence.
     Usage: /area_duplicate <aid>
     """
-    args = arg.split()
-
-    if len(args) == 1:
-        try:
-            area = client.area.area_manager.get_area_by_id(int(args[0]))
-            name = area.name
-            data = area.save()
-            new_area = client.area.area_manager.create_area()
-            new_area.load(data)
-            client.area.area_manager.broadcast_area_list()
-            client.send_ooc(f"Area {name} duplicated!")
-        except ValueError:
-            raise ArgumentError("Area ID must be a number.")
-        except (AreaError, ClientError):
-            raise
-    else:
-        raise ArgumentError(
-            "Invalid number of arguments. Use /area_duplicate <aid>.")
+    try:
+        area = client.area.area_manager.get_area_by_id(id)
+        name = area.name
+        data = area.save()
+        new_area = client.area.area_manager.create_area()
+        new_area.load(data)
+        client.area.area_manager.broadcast_area_list()
+        client.send_ooc(f"Area {name} duplicated!")
+    except ValueError:
+        raise ArgumentError("Area ID must be a number.")
+    except (AreaError, ClientError):
+        raise
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="[aid] <name>"))
 def ooc_cmd_area_rename(client, arg):
     """
     Rename the area to <name>. The area is the one you're currently in
@@ -428,43 +425,46 @@ def ooc_cmd_area_rename(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_area_swap(client, arg):
+@command(
+    Arg("id1", int, help="area ID"),
+    Arg("id2", int, help="area ID"),
+)
+def ooc_cmd_area_swap(client, id1, id2):
     """
     Swap areas by Area IDs while correcting links to reference the right areas.
     Usage: /area_swap <id> <id>
     """
-    args = arg.split()
-    if len(args) != 2:
-        raise ClientError("You must specify 2 numbers.")
     try:
-        area1 = client.area.area_manager.get_area_by_id(int(args[0]))
-        area2 = client.area.area_manager.get_area_by_id(int(args[1]))
+        area1 = client.area.area_manager.get_area_by_id(id1)
+        area2 = client.area.area_manager.get_area_by_id(id2)
         client.area.area_manager.swap_area(area1, area2, True)
         client.area.area_manager.broadcast_area_list()
         client.send_ooc(
-            f"Area {area1.name} has been swapped with Area {area2.name}!")
+            f"Area {area1.name} has been swapped with Area {area2.name}!"
+        )
     except ValueError:
         raise ArgumentError("Area IDs must be a number.")
     except (AreaError, ClientError):
         raise
 
-
 @mod_only(hub_owners=True)
-def ooc_cmd_area_switch(client, arg):
+@command(
+    Arg("id1", int, help="area ID"),
+    Arg("id2", int, help="area ID"),
+)
+def ooc_cmd_area_switch(client, id1, id2):
     """
     Switch areas by Area IDs without correcting links.
     Usage: /area_switch <id> <id>
     """
-    args = arg.split()
-    if len(args) != 2:
-        raise ClientError("You must specify 2 numbers.")
     try:
-        area1 = client.area.area_manager.get_area_by_id(int(args[0]))
-        area2 = client.area.area_manager.get_area_by_id(int(args[1]))
+        area1 = client.area.area_manager.get_area_by_id(id1)
+        area2 = client.area.area_manager.get_area_by_id(id2)
         client.area.area_manager.swap_area(area1, area2, False)
         client.area.area_manager.broadcast_area_list()
         client.send_ooc(
-            f"Area {area1.name} has been switched with Area {area2.name}!")
+            f"Area {area1.name} has been switched with Area {area2.name}!"
+        )
     except ValueError:
         raise ArgumentError("Area IDs must be a number.")
     except (AreaError, ClientError):
@@ -472,6 +472,7 @@ def ooc_cmd_area_switch(client, arg):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="[pref] [on/true/off/false]"))
 def ooc_cmd_area_pref(client, arg):
     """
     Toggle a preference on/off for an area.
@@ -535,17 +536,17 @@ def ooc_cmd_area_pref(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_area_move_delay(client, arg):
+@command(Arg("delay", int, default=None, help="delay in seconds (blank shows current)"))
+def ooc_cmd_area_move_delay(client, delay):
     """
     Set the area's move delay to a value in seconds. Can be negative.
     Delay must be from -1800 to 1800 in seconds or empty to check.
     Usage: /area_move_delay [delay]
     """
-    args = arg.split()
     try:
-        if len(args) > 0:
+        if delay is not None:
             move_delay = min(
-                1800, max(-1800, int(args[0]))
+                1800, max(-1800, delay)
             )  # Move delay is limited between -1800 and 1800
             client.area.move_delay = move_delay
             client.send_ooc(
@@ -554,24 +555,22 @@ def ooc_cmd_area_move_delay(client, arg):
             client.send_ooc(
                 f"Current move delay for {client.area.name} is {client.area.move_delay}."
             )
-    except ValueError:
-        raise ArgumentError("Delay must be an integer between -1800 and 1800.")
     except (AreaError, ClientError):
         raise
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_hub_move_delay(client, arg):
+@command(Arg("delay", int, default=None, help="delay in seconds (blank shows current)"))
+def ooc_cmd_hub_move_delay(client, delay):
     """
     Set the hub's move delay to a value in seconds. Can be negative.
     Delay must be from -1800 to 1800 in seconds or empty to check.
     Usage: /hub_move_delay [delay]
     """
-    args = arg.split()
     try:
-        if len(args) > 0:
+        if delay is not None:
             move_delay = min(
-                1800, max(-1800, int(args[0]))
+                1800, max(-1800, delay)
             )  # Move delay is limited between -1800 and 1800
             client.area.area_manager.move_delay = move_delay
             client.send_ooc(
@@ -581,22 +580,20 @@ def ooc_cmd_hub_move_delay(client, arg):
             client.send_ooc(
                 f"Current move delay for {client.area.area_manager.name} is {client.area.area_manager.move_delay}."
             )
-    except ValueError:
-        raise ArgumentError("Delay must be an integer between -1800 and 1800.")
     except (AreaError, ClientError):
         raise
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_toggle_replace_music(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_toggle_replace_music(client, tog):
     """
     Toggle the hub music list to replace the server's music list.
     Usage: /toggle_replace_music [true/false]
     """
-    boolean = not client.area.area_manager.replace_music
-    if len(arg) > 0:
-        boolean = arg in ["true", "on", "1"]
-    client.area.area_manager.replace_music = boolean
+    client.area.area_manager.replace_music = (
+        not client.area.area_manager.replace_music if tog is None else tog
+    )
     toggle = "now" if client.area.area_manager.replace_music else "no longer"
     client.server.client_manager.refresh_music(
         client.area.area_manager.clients)
@@ -606,15 +603,15 @@ def ooc_cmd_toggle_replace_music(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_toggle_passing_ic(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_toggle_passing_ic(client, tog):
     """
     Toggle an IC message when changing areas for this hub.
     Usage: /toggle_passing_ic
     """
-    boolean = not client.area.area_manager.passing_msg
-    if len(arg) > 0:
-        boolean = arg in ["true", "on", "1"]
-    client.area.area_manager.passing_msg = boolean
+    client.area.area_manager.passing_msg = (
+        not client.area.area_manager.passing_msg if tog is None else tog
+    )
     toggle = "enabled" if client.area.area_manager.passing_msg else "disabled"
     client.area.area_manager.broadcast_ooc(
         f"IC area passing messages are now {toggle} for this hub."
@@ -622,7 +619,8 @@ def ooc_cmd_toggle_passing_ic(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_arup_enable(client, arg):
+@command()
+def ooc_cmd_arup_enable(client):
     """
     Enable the ARea UPdate system for this hub.
     ARUP system is the extra information displayed in the A/M area list, as well as being able to set /status.
@@ -641,7 +639,8 @@ def ooc_cmd_arup_enable(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_arup_disable(client, arg):
+@command()
+def ooc_cmd_arup_disable(client):
     """
     Disable the ARea UPdate system for this hub.
     Usage: /arup_disable
@@ -661,15 +660,15 @@ def ooc_cmd_arup_disable(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_toggle_getareas(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_toggle_getareas(client, tog):
     """
     Toggle the permissions of /getareas for normal players in this hub.
     Usage: /toggle_getareas
     """
-    boolean = not client.area.area_manager.can_getareas
-    if len(arg) > 0:
-        boolean = arg in ["true", "on", "1"]
-    client.area.area_manager.can_getareas = boolean
+    client.area.area_manager.can_getareas = (
+        not client.area.area_manager.can_getareas if tog is None else tog
+    )
     toggle = "enabled" if client.area.area_manager.can_getareas else "disabled"
     client.area.area_manager.broadcast_ooc(
         f"Use of /getareas has been {toggle} for this hub."
@@ -677,15 +676,15 @@ def ooc_cmd_toggle_getareas(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_toggle_spectate(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_toggle_spectate(client, tog):
     """
     Disable the ability to use a spectator character for non-GMs for this hub.
     Usage: /toggle_spectate
     """
-    boolean = not client.area.area_manager.can_spectate
-    if len(arg) > 0:
-        boolean = arg in ["true", "on", "1"]
-    client.area.area_manager.can_spectate = boolean
+    client.area.area_manager.can_spectate = (
+        not client.area.area_manager.can_spectate if tog is None else tog
+    )
     toggle = "enabled" if client.area.area_manager.can_spectate else "disabled"
     client.area.area_manager.broadcast_ooc(
         f"Spectating has been {toggle} for this hub."
@@ -693,7 +692,8 @@ def ooc_cmd_toggle_spectate(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_hide_clients(client, arg):
+@command()
+def ooc_cmd_hide_clients(client):
     """
     Hide the playercounts for this Hub's areas.
     Usage: /hide_clients
@@ -710,7 +710,8 @@ def ooc_cmd_hide_clients(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_unhide_clients(client, arg):
+@command()
+def ooc_cmd_unhide_clients(client):
     """
     Unhide the playercounts for this Hub's areas.
     Usage: /unhide_clients
@@ -727,27 +728,24 @@ def ooc_cmd_unhide_clients(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_force_follow(client, arg):
+@command(
+    Arg("victim", int, help="victim client ID"),
+    Arg("target", int, default=None, help="target client ID (blank = you)"),
+)
+def ooc_cmd_force_follow(client, victim, target):
     """
     Force someone to follow you, or someone else. Follow me!
     Usage: /force_follow <victim_id> [target_id]
     """
-    arg = arg.split()
-    if len(arg) == 0:
-        raise ArgumentError(
-            "You must specify a victim. Usage: /force_follow <victim_id> [target_id]")
-    try:
-        victims = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(arg[0]), False
-        )
-    except Exception:
-        raise ArgumentError(
-            "You must specify a victim. Usage: /force_follow <victim_id> [target_id]")
-    target = client
-    if len(arg) >= 2:
+    victims = client.server.client_manager.get_targets(
+        client, TargetType.ID, victim, False
+    )
+    if target is None:
+        target = client
+    else:
         try:
             target = client.server.client_manager.get_targets(
-                client, TargetType.ID, int(arg[1]), False
+                client, TargetType.ID, target, False
             )
         except Exception:
             raise ArgumentError(
@@ -769,6 +767,7 @@ def ooc_cmd_force_follow(client, arg):
         client.send_ooc("No targets found.")
 
 
+@command(Arg("arg", rest=True, default="", help="client ID (blank checks)"))
 def ooc_cmd_follow(client, arg):
     """
     Follow targeted character ID.
@@ -822,6 +821,7 @@ def ooc_cmd_follow(client, arg):
         client.send_ooc("No targets found.")
 
 
+@command(Arg("arg", rest=True, default="", help="client ID (blank = unfollow yourself)"))
 def ooc_cmd_unfollow(client, arg):
     """
     Stop following whoever you are following, or free someone from being forced to follow.
@@ -892,6 +892,7 @@ def ooc_cmd_unfollow(client, arg):
         ooc_cmd_unfollow(client, "")
 
 
+@command(Arg("arg", rest=True, default="", help="info text (blank shows)"))
 def ooc_cmd_info(client, arg):
     """
     Check the information for the current Hub, or set it.
@@ -910,6 +911,7 @@ def ooc_cmd_info(client, arg):
         database.log_area("info.change", client, client.area, message=arg)
 
 
+@command(Arg("arg", rest=True, default="", help="client ID(s) or * (blank = self)"))
 def ooc_cmd_gm(client, arg):
     """
     Add a game master for the current Hub.
@@ -971,7 +973,8 @@ def ooc_cmd_gm(client, arg):
         raise ClientError("You must be authorized to do that.")
 
 
-def ooc_cmd_gmpanel(client, arg):
+@command()
+def ooc_cmd_gmpanel(client):
     """
     Generate a one-time link to open the web GM Control Panel bound to you.
     Usage: /gmpanel
@@ -989,6 +992,7 @@ def ooc_cmd_gmpanel(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="client ID(s) (blank = self)"))
 def ooc_cmd_ungm(client, arg):
     """
     Remove a game master from the current Hub.
@@ -1019,20 +1023,20 @@ def ooc_cmd_ungm(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_broadcast(client, arg):
+@command(Arg("areas", variadic=True, default=None, help="area IDs (blank shows current)"))
+def ooc_cmd_broadcast(client, areas):
     """
     Start broadcasting your IC, Music and Judge buttons to specified area ID's.
     To include all areas, use /broadcast all.
     /clear_broadcast to stop broadcasting.
     Usage: /broadcast <id(s)>
     """
-    args = shlex.split(arg)
-    if len(args) <= 0:
+    if not areas:
         a_list = ", ".join([str(a.id) for a in client.broadcast_list])
         client.send_ooc(f"Your broadcast list is {a_list}")
         return
     try:
-        broadcast_list = client.area.area_manager.get_areas_by_args(args)
+        broadcast_list = client.area.area_manager.get_areas_by_args(areas)
         # We don't modify the client.broadcast_list directly until now just in case there's an exception.
         client.broadcast_list = broadcast_list
         a_list = ", ".join([str(a.id) for a in client.broadcast_list])
@@ -1043,7 +1047,8 @@ def ooc_cmd_broadcast(client, arg):
         raise
 
 
-def ooc_cmd_clear_broadcast(client, arg):
+@command()
+def ooc_cmd_clear_broadcast(client):
     """
     Stop broadcasting your IC, Music and Judge buttons.
     Usage: /clear_broadcast
@@ -1056,45 +1061,36 @@ def ooc_cmd_clear_broadcast(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_hpset(client, arg):
+@command(
+    Arg("pos", choices=["pro", "def"], help="pro or def"),
+    Arg("amount", int, help="HP amount"),
+    Arg("areas", variadic=True, default=None, help="area IDs (blank = current)"),
+)
+def ooc_cmd_hpset(client, pos, amount, areas):
     """
     Set hp in area or multiple areas.
     To include all areas, use set [area] to all.
     Usage: /hpset <pos> <amount> [area]
     """
-    args = shlex.split(arg)
-    if len(args) == 0:
-        raise ArgumentError(
-            "You must specify a position and HP. Use /hpset <pos> <amount> [area]")
-    elif len(args) == 1:
-        raise ArgumentError(
-            "You must specify HP. Use /hpset <pos> <amount> [area]")
-
-    if args[0] == "def":
-        side = 1
-    elif args[0] == "pro":
-        side = 2
-    else:
-        raise ArgumentError(
-            "Invalid position. Use \"pro\" or \"def\"")
+    side = 1 if pos == "def" else 2
 
     area_list = [client.area]
-    if len(args) > 2:
-        area_list = client.area.area_manager.get_areas_by_args(args[1:])
+    if areas:
+        area_list = client.area.area_manager.get_areas_by_args(areas)
     for area in area_list:
-        area.change_hp(side, int(args[1]))
+        area.change_hp(side, amount)
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_toggle_autokick(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_toggle_autokick(client, tog):
     """
     when True, swapping to a character will instantly kick you to that character's latest area.
     Usage: /toggle_autokick
     """
-    boolean = not client.area.area_manager.autokick_to_latest_area
-    if len(arg) > 0:
-        boolean = arg in ["true", "on", "1"]
-    client.area.area_manager.autokick_to_latest_area = boolean
+    client.area.area_manager.autokick_to_latest_area = (
+        not client.area.area_manager.autokick_to_latest_area if tog is None else tog
+    )
     toggle = "enabled" if client.area.area_manager.autokick_to_latest_area else "disabled"
     client.area.area_manager.broadcast_ooc(
         f"Auto-kick to your picked character's latest area is now {toggle} for this hub."

--- a/server/commands/inventory.py
+++ b/server/commands/inventory.py
@@ -1,14 +1,11 @@
-import shlex
 import yaml
 import os
 
-import re
-
 from server import database
-from server.constants import TargetType, derelative
+from server.constants import TargetType
 from server.exceptions import ClientError, ServerError, ArgumentError, AreaError
 
-from . import mod_only
+from . import mod_only, command, Arg, tokens_str
 
 __all__ = [
     "ooc_cmd_inventory",
@@ -45,7 +42,7 @@ def get_inventory(evi_list, arg):
             raise AreaError(
                 f"Target evidence not found! (/inventory {arg})"
             )
-        msg = f"==💼[{i+1}]: '{evidence[0]}=="
+        msg = f"==💼[{i+1}]: '{evidence[0]}== "
         msg += f"\n🖼️Image: {evidence[2]}"
         msg += f"\n📃Desc:\n{evidence[1]}"
         msg += f"\n\n|| Use /inventory_drop {i} to drop this into the area ||"
@@ -56,6 +53,7 @@ def get_inventory(evi_list, arg):
         raise
 
 
+@command(Arg("arg", rest=True, default="", help="evidence name or id"))
 def ooc_cmd_inventory(client, arg):
     """
     Use /inventory to read all evidence in your inventory.
@@ -66,6 +64,7 @@ def ooc_cmd_inventory(client, arg):
     client.send_ooc(msg + get_inventory(client.inventory, arg))
 
 
+@command(Arg("arg", rest=True, default="", help="evidence name or id"))
 def ooc_cmd_inventory_drop(client, arg):
     """
     Use /inventory_drop [evi_name/id] to drop evidence from your inventory into the area.
@@ -121,125 +120,91 @@ def get_inventory_target(client, arg):
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_inventory_get(client, arg):
+@command(
+    Arg("target", help="character id, folder or name"),
+    Arg("name", rest=True, default="", type=tokens_str, help="evidence name or id"),
+)
+def ooc_cmd_inventory_get(client, target, name):
     """
     Get someone else's character inventory.
     Usage: /inventory_get <id>
     """
-    try:
-        # Get the user input
-        args = shlex.split(arg)
-        
-        target = get_inventory_target(client, args.pop(0))
-                
-        inventory = client.area.area_manager.get_character_data(target, "inventory", "")
-        charname = client.area.area_manager.char_list[target]
-        inventory_list = get_inventory(inventory, " ".join(args))
-        msg = f"==Evidence in '{charname}' inventory==\n{inventory_list}"
-        client.send_ooc(msg)
-        database.log_area(
-            "inventory.get", client, client.area, message=charname
-        )
-    except ValueError as ex:
-        client.send_ooc(f'{ex} (/inventory_get {arg})')
-        return
+    target = get_inventory_target(client, target)
+
+    inventory = client.area.area_manager.get_character_data(target, "inventory", "")
+    charname = client.area.area_manager.char_list[target]
+    inventory_list = get_inventory(inventory, name)
+    msg = f"==Evidence in '{charname}' inventory==\n{inventory_list}"
+    client.send_ooc(msg)
+    database.log_area(
+        "inventory.get", client, client.area, message=charname
+    )
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_inventory_add(client, arg):
+@command(
+    Arg("target", help="character id, folder or name"),
+    Arg("name", default="<name>", help="evidence name"),
+    Arg("description", default="<description>", help="evidence description"),
+    Arg("image", default="empty.png", help="evidence image"),
+)
+def ooc_cmd_inventory_add(client, target, name, description, image):
     """
     Use /inventory_add <target> [evi_name/id] to add evidence into their inventory.
     Usage: /inventory_add <target> [evi_name/id]
     """
-    try:
-        # Get the user input
-        args = shlex.split(arg)
-        
-        target = get_inventory_target(client, args.pop(0))
-
-        max_args = 3
-        if len(args) > max_args:
-            raise ArgumentError(
-                f"Too many arguments! Make sure to surround your args in \"\"'s if there's spaces. (/inventory_add {arg})")
-        # fill the rest of it with asterisk to fill to max_args
-        args = args + ([""] * (max_args - len(args)))
-        if args[0] == "":
-            args[0] = "<name>"
-        if args[1] == "":
-            args[1] = "<description>"
-        if args[2] == "":
-            args[2] = "empty.png"
-    except ValueError as ex:
-        client.send_ooc(f'{ex} (/inventory_add {arg})')
-        return
+    target = get_inventory_target(client, target)
 
     inventory = client.area.area_manager.get_character_data(target, "inventory", list())
-    inventory.append([args[0], args[1], args[2]])
+    inventory.append([name, description, image])
     client.area.area_manager.set_character_data(target, "inventory", inventory)
     charname = client.area.area_manager.char_list[target]
-    client.send_ooc(f"Added evidence '{args[0]}' into {charname}'s inventory")
+    client.send_ooc(f"Added evidence '{name}' into {charname}'s inventory")
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_inventory_remove(client, arg):
+@command(
+    Arg("target", help="character id, folder or name"),
+    Arg("name", rest=True, default="", type=tokens_str, help="evidence name or id"),
+)
+def ooc_cmd_inventory_remove(client, target, name):
     """
     Remove a piece of evidence from target's inventory.
     Usage: /inventory_remove <target_id> <evi_name/id>
     """
-    try:
-        args = shlex.split(arg)
-        target = get_inventory_target(client, args.pop(0))
-        if len(args) > 1:
-            raise ArgumentError(
-                f"Too many arguments! Make sure to surround your args in \"\"'s if there's spaces. (/inventory_remove {arg})")
+    target = get_inventory_target(client, target)
 
-        inventory = client.area.area_manager.get_character_data(target, "inventory", list())
-        
-        arg = " ".join(args)
-        evidence = None
-        for i, evi in enumerate(inventory):
-            if (arg.isnumeric() and int(arg) - 1 == i) or arg.lower() == evi[0].lower():
-                evidence = evi
-                break
-        if evidence is None:
-            raise AreaError(
-                f"Target evidence not found! (/inventory_remove {arg})"
-            )
-        inventory.pop(i)
-        client.area.area_manager.set_character_data(target, "inventory", inventory)
-    except ValueError as ex:
-        client.send_ooc(f'{ex} (/inventory_remove {arg})')
-        return
+    inventory = client.area.area_manager.get_character_data(target, "inventory", list())
+
+    evidence = None
+    for i, evi in enumerate(inventory):
+        if (name.isnumeric() and int(name) - 1 == i) or name.lower() == evi[0].lower():
+            evidence = evi
+            break
+    if evidence is None:
+        raise AreaError(
+            f"Target evidence not found! (/inventory_remove {name})"
+        )
+    inventory.pop(i)
+    client.area.area_manager.set_character_data(target, "inventory", inventory)
 
 
 @mod_only(hub_owners=True)
-def ooc_cmd_inventory_edit(client, arg):
+@command(
+    Arg("target", help="character id, folder or name"),
+    Arg("target_evi", help="evidence name or id"),
+    Arg("name", default="*", help="new evidence name"),
+    Arg("description", default="*", help="new evidence description"),
+    Arg("image", default="*", help="new evidence image"),
+)
+def ooc_cmd_inventory_edit(client, target, target_evi, name, description, image):
     """
     Edit a piece of evidence in target's inventory.
     If you don't want to change something, put an * there.
     For sentences with spaces the arg should be surrounded in ""'s, for example /inventory_edit * "It's a chair." chair.png
     Usage: /inventory_edit <target_id> <evi_name/id> [name] [desc] [image]
     """
-    if arg == "":
-        raise ArgumentError(
-            "Use /inventory_edit <target> <evi_name/id> [name] [desc] [image] to edit that piece of evidence."
-        )
-
-    try:
-        # Get the user input
-        args = shlex.split(arg)
-        target = get_inventory_target(client, args.pop(0))
-        target_evi = args.pop(0)
-
-        max_args = 3
-        if len(args) > max_args:
-            raise ArgumentError(
-                f"Too many arguments! Make sure to surround your args in \"\"'s if there's spaces. (/inventory_edit {arg})")
-        # fill the rest of it with asterisk to fill to max_args
-        args = args + (["*"] * (max_args - len(args)))
-    except ValueError as ex:
-        client.send_ooc(f'{ex} (/inventory_edit {arg})')
-        return
+    target = get_inventory_target(client, target)
 
     try:
         inventory = client.area.area_manager.get_character_data(target, "inventory", list())
@@ -250,19 +215,20 @@ def ooc_cmd_inventory_edit(client, arg):
                 break
         if evidence is None:
             raise AreaError(
-                f"Target evidence not found! (/inventory_edit {arg})"
+                f"Target evidence not found! (/inventory_edit {target_evi})"
             )
         evi_name = evidence[0]
-        inventory[i] = [args[0], args[1], args[2]]
+        inventory[i] = [name, description, image]
         client.area.area_manager.set_character_data(target, "inventory", inventory)
         database.log_area("inventory.edit", client, client.area)
         charname = client.area.area_manager.char_list[target]
-        if args[0] != "*" and target_evi != args[0]:
+        if name != "*" and target_evi != name:
             client.send_ooc(
-                f"You have edited evidence '{evi_name}' to '{args[0]}' in {charname}'s inventory.")
+                f"You have edited evidence '{evi_name}' to '{name}' in {charname}'s inventory."
+            )
         else:
             client.send_ooc(f"You have edited evidence '{evi_name}' in {charname}'s inventory.")
     except ValueError:
         raise
     except (AreaError, ClientError):
-        raise
+        raise

--- a/server/commands/messaging.py
+++ b/server/commands/messaging.py
@@ -1,8 +1,8 @@
 from server import database
 from server.constants import TargetType
-from server.exceptions import ClientError, ArgumentError, AreaError
+from server.exceptions import ClientError, ArgumentError
 
-from . import mod_only
+from . import mod_only, command, Arg
 
 __all__ = [
     "ooc_cmd_g",
@@ -28,6 +28,7 @@ def message_areas_cm(client, areas, message):
         database.log_area("chat.cm", client, a, message=message)
 
 
+@command(Arg("arg", rest=True, default="", help="message"))
 def ooc_cmd_g(client, arg):
     """
     Broadcast a server-wide message.
@@ -43,6 +44,7 @@ def ooc_cmd_g(client, arg):
     database.log_area("chat.global", client, client.area, message=arg)
 
 
+@command(Arg("arg", rest=True, default="", help="message"))
 def ooc_cmd_h(client, arg):
     """
     Broadcast a hub-wide message.
@@ -63,6 +65,7 @@ def ooc_cmd_h(client, arg):
 
 
 @mod_only()
+@command(Arg("arg", rest=True, default="", help="message"))
 def ooc_cmd_m(client, arg):
     """
     Send a message to all online moderators.
@@ -75,6 +78,7 @@ def ooc_cmd_m(client, arg):
 
 
 @mod_only()
+@command(Arg("arg", rest=True, default="", help="message"))
 def ooc_cmd_announce(client, arg):
     """
     Make a server-wide announcement.
@@ -91,15 +95,13 @@ def ooc_cmd_announce(client, arg):
     database.log_area("chat.announce", client, client.area, message=arg)
 
 
-def ooc_cmd_toggleglobal(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_toggleglobal(client, tog):
     """
     Mute global chat.
     Usage: /toggleglobal
     """
-    boolean = not client.muted_global
-    if len(arg) > 0:
-        boolean = arg in ["true", "on", "1"]
-    client.muted_global = boolean
+    client.muted_global = not client.muted_global if tog is None else tog
     glob_stat = "on"
     if client.muted_global:
         glob_stat = "off"
@@ -107,6 +109,7 @@ def ooc_cmd_toggleglobal(client, arg):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="message"))
 def ooc_cmd_need(client, arg):
     """
     Broadcast a server-wide advertisement for your role-play or case.
@@ -126,21 +129,20 @@ def ooc_cmd_need(client, arg):
     database.log_area("chat.announce.need", client, client.area, message=arg)
 
 
-def ooc_cmd_toggleadverts(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_toggleadverts(client, tog):
     """
     Mute advertisements.
     Usage: /toggleadverts
     """
-    boolean = not client.muted_adverts
-    if len(arg) > 0:
-        boolean = arg in ["true", "on", "1"]
-    client.muted_adverts = not boolean
+    client.muted_adverts = not (not client.muted_adverts if tog is None else tog)
     adv_stat = "on"
     if client.muted_adverts:
         adv_stat = "off"
     client.send_ooc(f"Advertisements turned {adv_stat}.")
 
 
+@command(Arg("arg", rest=True, default="", help="<target> <message>"))
 def ooc_cmd_pm(client, arg):
     """
     Send a private message to one or more online users. These messages are not
@@ -231,13 +233,12 @@ def ooc_cmd_pm(client, arg):
         )
 
 
-def ooc_cmd_mutepm(client, arg):
+@command()
+def ooc_cmd_mutepm(client):
     """
     Mute private messages.
     Usage: /mutepm
     """
-    if len(arg) != 0:
-        raise ArgumentError("This command doesn't take any arguments")
     client.pm_mute = not client.pm_mute
     client.send_ooc(
         "You stopped receiving PMs" if client.pm_mute else "You are now receiving PMs"

--- a/server/commands/music.py
+++ b/server/commands/music.py
@@ -7,7 +7,7 @@ from server import database
 from server.constants import TargetType, derelative, contains_URL
 from server.exceptions import ClientError, ServerError, ArgumentError, AreaError
 
-from . import mod_only
+from . import mod_only, command, Arg
 
 __all__ = [
     "ooc_cmd_currentmusic",
@@ -30,13 +30,12 @@ __all__ = [
 ]
 
 
-def ooc_cmd_currentmusic(client, arg):
+@command()
+def ooc_cmd_currentmusic(client):
     """
     Show the current music playing.
     Usage: /currentmusic
     """
-    if len(arg) != 0:
-        raise ArgumentError("This command has no arguments.")
     if client.area.music == "":
         raise ClientError("There is no music currently playing.")
     if client.is_mod:
@@ -55,13 +54,12 @@ def ooc_cmd_currentmusic(client, arg):
         )
 
 
-def ooc_cmd_getmusic(client, arg):
+@command()
+def ooc_cmd_getmusic(client):
     """
     Grab the last played track in this area.
     Usage: /getmusic
     """
-    if len(arg) != 0:
-        raise ArgumentError("This command has no arguments.")
     if client.area.music == "":
         raise ClientError("There is no music currently playing.")
     client.send_command(
@@ -77,14 +75,13 @@ def ooc_cmd_getmusic(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_jukebox_toggle(client, arg):
+@command()
+def ooc_cmd_jukebox_toggle(client):
     """
     Toggle jukebox mode. While jukebox mode is on, all music changes become
     votes for the next track, rather than changing the track immediately.
     Usage: /jukebox_toggle
     """
-    if len(arg) != 0:
-        raise ArgumentError("This command has no arguments.")
     client.area.jukebox = not client.area.jukebox
     client.area.jukebox_votes = []
     client.area.broadcast_ooc(
@@ -98,13 +95,12 @@ def ooc_cmd_jukebox_toggle(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_jukebox_skip(client, arg):
+@command()
+def ooc_cmd_jukebox_skip(client):
     """
     Skip the current track.
     Usage: /jukebox_skip
     """
-    if len(arg) != 0:
-        raise ArgumentError("This command has no arguments.")
     if not client.area.jukebox:
         raise ClientError("This area does not have a jukebox.")
     if len(client.area.jukebox_votes) == 0:
@@ -126,13 +122,12 @@ def ooc_cmd_jukebox_skip(client, arg):
     database.log_area("jukebox_skip", client, client.area)
 
 
-def ooc_cmd_jukebox(client, arg):
+@command()
+def ooc_cmd_jukebox(client):
     """
     Show information about the jukebox's queue and votes.
     Usage: /jukebox
     """
-    if len(arg) != 0:
-        raise ArgumentError("This command has no arguments.")
     if not client.area.jukebox:
         raise ClientError("This area does not have a jukebox.")
     if len(client.area.jukebox_votes) == 0:
@@ -178,42 +173,36 @@ def ooc_cmd_jukebox(client, arg):
         client.send_ooc(f"The jukebox has the following songs in it:{message}")
 
 
+@command(Arg("arg", rest=True, default="", help="track name"))
 def ooc_cmd_play(client, arg):
     """
     Play a track and loop it. See /play_once for this command without looping.
     Usage: /play <name>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a song.")
     client.change_music(arg, client.char_id, "", 2,
                         True)  # looped change music
 
 
+@command(Arg("arg", rest=True, default="", help="track name"))
 def ooc_cmd_play_once(client, arg):
     """
     Play a track without looping it. See /play for this command with looping.
     Usage: /play_once <name>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a song.")
     client.change_music(arg, client.char_id, "", 2,
                         False)  # non-looped change music
 
 
 @mod_only()
-def ooc_cmd_blockdj(client, arg):
+@command(Arg("id", int, help="client ID"))
+def ooc_cmd_blockdj(client, id):
     """
     Prevent a user from changing music.
     Usage: /blockdj <id>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target. Use /blockdj <id>.")
-    try:
-        targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(arg), False
-        )
-    except Exception:
-        raise ArgumentError("You must enter a number. Use /blockdj <id>.")
+    targets = client.server.client_manager.get_targets(
+        client, TargetType.ID, id, False
+    )
     if not targets:
         raise ArgumentError("Target not found. Use /blockdj <id>.")
     for target in targets:
@@ -225,19 +214,15 @@ def ooc_cmd_blockdj(client, arg):
 
 
 @mod_only()
-def ooc_cmd_unblockdj(client, arg):
+@command(Arg("id", int, help="client ID"))
+def ooc_cmd_unblockdj(client, id):
     """
     Unblock a user from changing music.
     Usage: /unblockdj <id>
     """
-    if len(arg) == 0:
-        raise ArgumentError("You must specify a target. Use /unblockdj <id>.")
-    try:
-        targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(arg), False
-        )
-    except Exception:
-        raise ArgumentError("You must enter a number. Use /unblockdj <id>.")
+    targets = client.server.client_manager.get_targets(
+        client, TargetType.ID, id, False
+    )
     if not targets:
         raise ArgumentError("Target not found. Use /blockdj <id>.")
     for target in targets:
@@ -247,7 +232,8 @@ def ooc_cmd_unblockdj(client, arg):
     client.send_ooc("Unblockdj'd {}.".format(targets[0].char_name))
 
 
-def ooc_cmd_musiclists(client, arg):
+@command()
+def ooc_cmd_musiclists(client):
     """
     Displays all the available musiclists.
     Usage: /musiclists
@@ -283,6 +269,7 @@ def ooc_cmd_musiclists(client, arg):
     client.send_ooc(msg)
 
 
+@command(Arg("arg", rest=True, default="", help="musiclist path (blank resets)"))
 def ooc_cmd_musiclist(client, arg):
     """
     Load a client-side musiclist. Pass no arguments to reset. /musiclists to see available lists.
@@ -309,6 +296,7 @@ def ooc_cmd_musiclist(client, arg):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="musiclist path (blank resets)"))
 def ooc_cmd_area_musiclist(client, arg):
     """
     Load an area-wide musiclist. Pass no arguments to reset. /musiclists to see available lists.
@@ -335,6 +323,7 @@ def ooc_cmd_area_musiclist(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="musiclist path (blank resets)"))
 def ooc_cmd_hub_musiclist(client, arg):
     """
     Load a hub-wide musiclist. Pass no arguments to reset. /musiclists to see available lists.
@@ -361,6 +350,7 @@ def ooc_cmd_hub_musiclist(client, arg):
         client.send_ooc("File not found!")
 
 
+@command(Arg("arg", rest=True, default="", help="category name (blank = any)"))
 def ooc_cmd_random_music(client, arg):
     """
     Play a random track from your current musiclist. If supplied, [category] will pick the song from that category.
@@ -400,6 +390,7 @@ def musiclist_rebuild(musiclist, path):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="<local/area/hub> [name] [read_only]"))
 def ooc_cmd_musiclist_save(client, arg):
     """
     Allow you to save a musiclist on server list!
@@ -451,6 +442,9 @@ def ooc_cmd_musiclist_save(client, arg):
     client.send_ooc(f"Musiclist '{name}' saved on server list!")
 
 
+@command(
+    Arg("arg", rest=True, default="", help="<local/area/hub> <Category> <MusicName>"),
+)
 def ooc_cmd_musiclist_remove(client, arg):
     """
     Allow you to remove a song from a musiclist!
@@ -535,6 +529,9 @@ def ooc_cmd_musiclist_remove(client, arg):
     client.send_ooc(f"'{args[2]}' song has been removed to '{path}' musiclist.")
 
 
+@command(
+    Arg("arg", rest=True, default="", help="<local/area/hub> <Category> <MusicName> [Length] [Path]"),
+)
 def ooc_cmd_musiclist_add(client, arg):
     """
     Allow you to add a song in a loaded musiclist!

--- a/server/commands/roleplay.py
+++ b/server/commands/roleplay.py
@@ -12,7 +12,7 @@ from server.exceptions import ClientError, ServerError, ArgumentError
 from server.remote_client import RemoteClient
 from server.scripting import evaluate_expression, ScriptingError, DivisionByZeroError
 
-from . import mod_only
+from . import mod_only, command, Arg
 
 __all__ = [
     "ooc_cmd_roll",
@@ -143,6 +143,7 @@ def rtd(arg):
     return roll, num_dice, chosen_max, modifiers, Sum
 
 
+@command(Arg("arg", rest=True, default="", help="[value/XdY] [modifier]"))
 def ooc_cmd_roll(client, arg):
     """
     Roll a die. The result is shown publicly.
@@ -160,6 +161,7 @@ def ooc_cmd_roll(client, arg):
     database.log_area("roll", client, client.area, message=f"{roll} out of {chosen_max}")
 
 
+@command(Arg("arg", rest=True, default="", help="[value/XdY] [modifier]"))
 def ooc_cmd_rollp(client, arg):
     """
     Roll a die privately. Same as /roll but the result is only shown to you and the CMs.
@@ -182,6 +184,7 @@ def ooc_cmd_rollp(client, arg):
     database.log_area("rollp", client, client.area, message=f"{roll} out of {chosen_max}")
 
 
+@command(Arg("arg", rest=True, default="", help="message (blank shows yours)"))
 def ooc_cmd_notecard(client, arg):
     """
     Write a notecard that can only be revealed by a CM.
@@ -201,7 +204,8 @@ def ooc_cmd_notecard(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_notecard_clear(client, arg):
+@command()
+def ooc_cmd_notecard_clear(client):
     """
     Clear all notecards as a CM.
     Usage: /notecard_clear
@@ -212,7 +216,8 @@ def ooc_cmd_notecard_clear(client, arg):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_notecard_reveal(client, arg):
+@command(Arg("autoclear", bool, default=True, help="off/0/false keeps the cards"))
+def ooc_cmd_notecard_reveal(client, autoclear):
     """
     Reveal all notecards and their owners.
     Set [clear] to 0 if you don't want the notecards to automatically clear after revealing.
@@ -235,17 +240,18 @@ def ooc_cmd_notecard_reveal(client, arg):
     client.area.broadcast_ooc(msg)
 
     # Check if notecards auto-clear or not
-    if arg.strip().lower() in ("0", "off", "false"):
-        client.send_ooc("Use /notecard_clear for clearing.")
-    else:
+    if autoclear:
         client.area.cards.clear()
         client.area.broadcast_ooc(f"Notecards have been cleared.")
+    else:
+        client.send_ooc("Use /notecard_clear for clearing.")
 
     database.log_area("notecard_reveal", client, client.area)
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_notecard_check(client, arg):
+@command()
+def ooc_cmd_notecard_check(client):
     """
     Check all notecards and their owners privately with a message telling others you've done so.
     Usage: /notecard_check
@@ -269,23 +275,25 @@ def ooc_cmd_notecard_check(client, arg):
     database.log_area("notecard_check", client, client.area)
 
 
-def ooc_cmd_vote(client, arg):
+@command(Arg("id", int, help="target client ID"))
+def ooc_cmd_vote(client, id):
     """
     Cast a vote for a particular user that can only be revealed by a CM.
     Usage: /vote <id>
     """
-    args = arg.split()
-    if len(args) == 0:
-        raise ArgumentError("Please provide a client ID. Usage: /vote <id>.")
     if client.char_name in [y for x in client.area.votes.values() for y in x]:
         raise ArgumentError("You already cast your vote! Wait on the CM to /vote_clear.")
-    target = client.server.client_manager.get_targets(client, TargetType.ID, int(args[0]), False)[0]
+    targets = client.server.client_manager.get_targets(client, TargetType.ID, id, False)
+    if not targets:
+        raise ArgumentError("Target not found.")
+    target = targets[0]
     client.area.votes.setdefault(target.char_name, []).append(client.char_name)
     client.area.broadcast_ooc(f"[{client.id}] {client.showname} cast a vote.")
     database.log_area("vote", client, client.area)
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="voter char folder (blank clears all)"))
 def ooc_cmd_vote_clear(client, arg):
     """
     Clear all votes as a CM.
@@ -351,7 +359,8 @@ def get_vote_results(client, votes):
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_vote_reveal(client, arg):
+@command(Arg("autoclear", bool, default=True, help="off/0/false keeps the votes"))
+def ooc_cmd_vote_reveal(client, autoclear):
     """
     Reveal the number of votes, the voters and those with the highest amount of votes.
     Usage: /vote_reveal
@@ -363,17 +372,18 @@ def ooc_cmd_vote_reveal(client, arg):
     client.area.broadcast_ooc(msg)
 
     # Check if votes auto-clear or not
-    if arg.strip().lower() in ("0", "off", "false"):
-        client.send_ooc("Use /vote_clear for clearing.")
-    else:
+    if autoclear:
         client.area.votes.clear()
         client.area.broadcast_ooc(f"Votes have been cleared.")
+    else:
+        client.send_ooc("Use /vote_clear for clearing.")
 
     database.log_area("vote_reveal", client, client.area)
 
 
 @mod_only(area_owners=True)
-def ooc_cmd_vote_check(client, arg):
+@command()
+def ooc_cmd_vote_check(client):
     """
     Check the number of votes, the voters and those with the highest amount of votes privately with a message telling others you've done so.
     Usage: /vote_check
@@ -389,7 +399,8 @@ def ooc_cmd_vote_check(client, arg):
 
 
 @mod_only()
-def ooc_cmd_rolla_reload(client, arg):
+@command()
+def ooc_cmd_rolla_reload(client):
     """
     Reload ability dice sets from a configuration file.
     Usage: /rolla_reload
@@ -409,6 +420,7 @@ def rolla_reload(area):
         raise ServerError("There was an error parsing the ability dice configuration. Check your syntax.")
 
 
+@command(Arg("arg", rest=True, default="", help="ability set name"))
 def ooc_cmd_rolla_set(client, arg):
     """
     Choose the set of ability dice to roll.
@@ -432,7 +444,8 @@ def rolla(ability_dice):
     return (roll, max_roll, ability)
 
 
-def ooc_cmd_rolla(client, arg):
+@command()
+def ooc_cmd_rolla(client):
     """
     Roll a specially labeled set of dice (ability dice).
     Usage: /rolla
@@ -447,26 +460,25 @@ def ooc_cmd_rolla(client, arg):
     database.log_area("rolla", client, client.area, message=f"{roll} out of {max_roll}: {ability}")
 
 
-def ooc_cmd_coinflip(client, arg):
+@command()
+def ooc_cmd_coinflip(client):
     """
     Flip a coin. The result is shown publicly.
     Usage: /coinflip
     """
-    if len(arg) != 0:
-        raise ArgumentError("This command has no arguments.")
     coin = ["heads", "tails"]
     flip = random.choice(coin)
     client.area.broadcast_ooc(f"[{client.id}] {client.showname} flipped a coin and got {flip}.")
     database.log_area("coinflip", client, client.area, message=flip)
 
 
+@command(Arg("arg", rest=True, help="your question"))
 def ooc_cmd_8ball(client, arg):
     """
     Answers a question. The result is shown publicly.
     Usage: /8ball <question>
     """
 
-    arg = arg.strip()
     if len(arg) == 0:
         raise ArgumentError("You need to ask a question")
     if len(arg) > 128:
@@ -478,6 +490,7 @@ def ooc_cmd_8ball(client, arg):
     )
 
 
+@command(Arg("arg", rest=True, default="", help="your choice (blank shows rules)"))
 def ooc_cmd_rps(client, arg):
     """
     Starts a match of Rock Paper Scissors.
@@ -599,6 +612,7 @@ def ooc_cmd_rps(client, arg):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="action + rule, e.g. add rock beats scissors"))
 def ooc_cmd_rps_rules(client, arg):
     """
     Review or change rps rules
@@ -646,6 +660,7 @@ def ooc_cmd_rps_rules(client, arg):
         raise ArgumentError("Invalid parameter!")
 
 
+@command(Arg("arg", rest=True, default="", help="<id> [time/start/pause/unset/cmd]"))
 def ooc_cmd_timer(client, arg):
     """
     Manage a countdown timer in the current area. Note that timer of ID `0` is hub-wide. All other timer ID's are local to area.
@@ -804,6 +819,7 @@ def ooc_cmd_timer(client, arg):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="evidence name/id (blank stops)"))
 def ooc_cmd_demo(client, arg):
     """
     Usage:
@@ -837,6 +853,7 @@ def ooc_cmd_demo(client, arg):
 
 
 @mod_only(hub_owners=True)
+@command(Arg("arg", rest=True, default="", help="all (or blank for this area)"))
 def ooc_cmd_stop_demo(client, arg):
     """
     Stop demo playback. Stops the demo in the current area, or all demos in
@@ -863,6 +880,7 @@ def ooc_cmd_stop_demo(client, arg):
 
 
 @mod_only(area_owners=True)
+@command(Arg("arg", rest=True, default="", help="trig cmd arg(s)"))
 def ooc_cmd_trigger(client, arg):
     """
     Set up a trigger for this area which, when fulfilled, will call the command.
@@ -919,6 +937,7 @@ def ooc_cmd_trigger(client, arg):
         client.send_ooc(f'Changed to Call "{val}" on trigger "{trig}"')
 
 
+@command(Arg("arg", rest=True, default="", help="<Timer_ID> <Format>"))
 def ooc_cmd_format_timer(client, arg):
     """
     - Format the timer in the current area or hub.
@@ -960,6 +979,7 @@ def ooc_cmd_format_timer(client, arg):
     client.send_ooc(f"Timer {args[0]} format: '{timer.format}'")
 
 
+@command(Arg("arg", rest=True, default="", help="<Timer_ID> <Interval>"))
 def ooc_cmd_timer_interval(client, arg):
     """
     Set timer interval
@@ -996,29 +1016,21 @@ def ooc_cmd_timer_interval(client, arg):
     client.send_ooc(f"Timer {args[0]} interval is set to '{args[1]}'")
 
 
-def ooc_cmd_ooc_actions(client, arg):
+@command(Arg("tog", bool, default=None, help="on/off"))
+def ooc_cmd_ooc_actions(client, tog):
     """
     Enable or disable IC actions being broadcast to OOC as well.
     tog can be `on`, `off` or empty.
     Usage: /ooc_actions [tog]
     """
-    if len(arg.split()) > 1:
-        raise ArgumentError("This command can only take one argument ('on' or 'off') or no arguments at all!")
-    if arg:
-        if arg == "on":
-            client.ooc_actions = True
-        elif arg == "off":
-            client.ooc_actions = False
-        else:
-            raise ArgumentError("Invalid argument: {}".format(arg))
-    else:
-        client.ooc_actions = not client.ooc_actions
+    client.ooc_actions = not client.ooc_actions if tog is None else tog
     stat = "no longer see"
     if client.ooc_actions:
         stat = "now see"
     client.send_ooc(f"You will {stat} actions in OOC.")
 
 
+@command(Arg("arg", rest=True, default="", help="sound path (e.g. sfx-name.ogg)"))
 def ooc_cmd_sfx(client, arg):
     """
     Play a sound effect directly without associating it with an IC message.

--- a/server/web_view/gm_panel/commands_meta.py
+++ b/server/web_view/gm_panel/commands_meta.py
@@ -98,8 +98,5 @@ class CommandLister:
 
     @classmethod
     def invalidate(cls):
-        """
-        Cache-bust hook for a future cheap `server.commands.reload()` integration
-        -- not currently wired to anything.
-        """
+        """Drop the cached catalog; called by `server.commands.reload()` (/refresh)."""
         cls._cache = None

--- a/tests/test_command_args.py
+++ b/tests/test_command_args.py
@@ -1,0 +1,171 @@
+import pytest
+
+from server.commands import Arg, command, parse_command_args, tokens_str
+from server.exceptions import ArgumentError
+
+
+def parse(raw, *args, usage=""):
+    return parse_command_args(raw, args, usage)
+
+
+# --- terminal parsing ---
+
+
+def test_no_args_command_rejects_input():
+    assert parse("") == {}
+    with pytest.raises(ArgumentError, match="takes no arguments"):
+        parse("x")
+
+
+def test_required_then_optional_positional():
+    spec = (Arg("a", int), Arg("b", default=""))
+    assert parse("5", *spec) == {"a": 5, "b": ""}
+    assert parse("5 x", *spec) == {"a": 5, "b": "x"}
+
+
+def test_missing_extraneous_and_bad_int_errors_include_usage():
+    with pytest.raises(ArgumentError, match=r"Not enough arguments\. Usage: /x <a>"):
+        parse("", Arg("a", int), usage="Usage: /x <a>")
+    with pytest.raises(ArgumentError, match=r"Too many arguments\. Usage: /x <a>"):
+        parse("1 2", Arg("a", int), usage="Usage: /x <a>")
+    with pytest.raises(ArgumentError, match=r"a must be a number\. Usage: /x <a>"):
+        parse("x", Arg("a", int), usage="Usage: /x <a>")
+
+
+def test_quotes_and_escapes_are_honored():
+    assert parse('"a b" c', Arg("x"), Arg("y")) == {"x": "a b", "y": "c"}
+    assert parse("'a b'", Arg("x")) == {"x": "a b"}
+    assert parse("a\\ b", Arg("x")) == {"x": "a b"}
+
+
+def test_bool_accepts_common_toggles():
+    spec = (Arg("tog", bool, default=None),)
+    assert parse("on", *spec) == {"tog": True}
+    assert parse("OFF", *spec) == {"tog": False}
+    assert parse("1", *spec) == {"tog": True}
+    assert parse("", *spec) == {"tog": None}
+    with pytest.raises(ArgumentError, match="Invalid value for tog"):
+        parse("maybe", *spec)
+
+
+def test_choices_match_case_insensitively_and_return_canonical():
+    spec = (Arg("side", choices=["pro", "def"]),)
+    assert parse("PRO", *spec) == {"side": "pro"}
+    assert parse("Def", *spec) == {"side": "def"}
+    with pytest.raises(ArgumentError, match="Expected one of"):
+        parse("left", *spec)
+
+
+# --- rest / variadic ---
+
+
+def test_rest_preserves_raw_text():
+    assert parse("hello   world", Arg("arg", rest=True)) == {
+        "arg": "hello   world"
+    }
+    assert parse("", Arg("arg", rest=True, default="")) == {"arg": ""}
+    assert tokens_str("a  'b c'  d") == "a b c d"
+
+
+def test_rest_after_fixed_args_keeps_remainder():
+    assert parse("x 'hi' yo", Arg("a"), Arg("arg", rest=True, default="")) == {
+        "a": "x",
+        "arg": "'hi' yo",
+    }
+
+
+def test_variadic_collects_and_converts_all_tokens():
+    assert parse("1 2 3", Arg("ids", int, variadic=True)) == {"ids": [1, 2, 3]}
+    assert parse("", Arg("ids", int, variadic=True, default=[])) == {"ids": []}
+    with pytest.raises(ArgumentError, match="ids must be a number"):
+        parse("1 x", Arg("ids", int, variadic=True))
+    with pytest.raises(ArgumentError, match="Not enough arguments"):
+        parse("", Arg("ids", int, variadic=True))
+
+
+def test_rest_and_variadic_must_be_last():
+    with pytest.raises(ValueError, match="last"):
+        Arg("after", variadic=True) and command(Arg("pre"), Arg("x", variadic=True), Arg("y"))
+
+
+@pytest.mark.parametrize(
+    "spec_kwargs",
+    [
+        {"required": True, "default": ""},
+        {"rest": True, "variadic": True},
+    ],
+)
+def test_invalid_arg_configurations_raise(spec_kwargs):
+    with pytest.raises(ValueError):
+        Arg("x", **spec_kwargs)
+
+
+def test_required_after_optional_spec_rejected():
+    with pytest.raises(ValueError, match="follows an optional argument"):
+        command(Arg("a", default=""), Arg("b"))
+
+
+# --- decorator ---
+
+
+def test_decorator_still_accepts_raw_string():
+    @command(Arg("target", int, required=True), Arg("reason", default="", rest=True))
+    def ooc_cmd_kick(client, target, reason):
+        return client, target, reason
+
+    assert ooc_cmd_kick(None, "5 this is why") == (None, 5, "this is why")
+
+
+def test_decorator_preserves_name_doc_and_spec():
+    @command(Arg("a", int))
+    def ooc_cmd_test_deco(client, a):
+        """Docstring here.
+        Usage: /test_deco <a>
+        """
+
+    assert ooc_cmd_test_deco.__name__ == "ooc_cmd_test_deco"
+    assert "Docstring here" in ooc_cmd_test_deco.__doc__
+    assert ooc_cmd_test_deco.command_spec[0].name == "a"
+
+
+def test_decorator_accepts_no_args_and_rejects_input():
+    @command()
+    def ooc_cmd_quiet(client):
+        return "done"
+
+    assert ooc_cmd_quiet(None, "") == "done"
+    with pytest.raises(ArgumentError, match="takes no arguments"):
+        ooc_cmd_quiet(None, "x")
+
+
+def test_usage_line_pulled_from_docstring():
+    @command(Arg("a", int))
+    def ooc_cmd_doc_usage(client, a):
+        """Do a thing.
+        Usage: /doc_usage <a>
+        """
+
+    assert ooc_cmd_doc_usage.command_usage == "Usage: /doc_usage <a>"
+    with pytest.raises(ArgumentError, match="Usage: /doc_usage <a>"):
+        ooc_cmd_doc_usage(None, "x")
+
+
+def test_usage_line_continuation_when_usage_on_own_line():
+    @command()
+    def ooc_cmd_multiline_usage(client):
+        """Do a thing.
+
+        Usage:
+        /multiline_usage <x>
+        """
+
+    assert ooc_cmd_multiline_usage.command_usage == "Usage: /multiline_usage <x>"
+
+
+def test_raises_inside_command_body_pass_through():
+    @command(Arg("n", int))
+    def ooc_cmd_bodierr(client, n):
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        ooc_cmd_bodierr(None, "5")


### PR DESCRIPTION
The OOC slash commands now finally have decorators that let you declare what arguments they actually expect. This should fix the age-old problem of having to re-write specific argument parsers over and over again, with each command handling argument parsing differently, some handling shlex args, some not handling it, etc. etc.

This should simplify making new commands and remvoe a lot of redundant, repetitive code from the command parsing letting you focus on adding just command-related code.

Since this is a major overhaul, ALL commands in the codebase have to be tested before this goes live.