### PR TITLE
Ratelimits

### DIFF
--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -128,6 +128,19 @@ connection_rate_limit:
 packet_rate_limit:
   max_per_second: 25
 
+# Global server-wide new connections per second cap.
+# Limits total new TCP connections across ALL IPs per second.
+# Set max_per_second to 0 to disable. (Default: 0 = disabled)
+global_connection_rate:
+  max_per_second: 5
+
+# Minimum seconds a client must be connected before they can send IC or CC.
+# Mods and CMs are exempt. Helps slow connect-spam-disconnect attacks.
+# Set to 0 to disable. (Default: 0 = disabled)
+min_connection_age:
+  before_ic: 3
+  before_cc: 3
+
 # Minimum milliseconds between /demo calls before rate limiting kicks in.
 # Set to 0 or less to disable demo rate limiting entirely. (Default: 0)
 demo_rate_limit_ms: 0

--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -94,17 +94,39 @@ debug: false
 music_change_floodguard:
   times_per_interval: 3
   interval_length: 20
-  mute_length: 180
+  mute_length: 60
 
 wtce_floodguard:
   times_per_interval: 5
   interval_length: 10
-  mute_length: 1000
+  mute_length: 60
   
 ooc_floodguard:
   times_per_interval: 5
   interval_length: 5
-  mute_length: 30
+  mute_length: 15
+
+ic_floodguard:
+  times_per_interval: 5
+  interval_length: 2
+  mute_length: 7
+
+cc_floodguard:
+  times_per_interval: 5
+  interval_length: 3
+  mute_length: 15
+
+# Per-IP connection rate limit.
+# max_connections: max new connections from one IP within interval_length seconds.
+# Set max_connections to 0 to disable. (Default: 0 = disabled)
+connection_rate_limit:
+  max_connections: 5
+  interval_length: 5
+
+# Global packet-per-second throttle per client.
+# Set max_per_second to 0 to disable. (Default: 0 = disabled)
+packet_rate_limit:
+  max_per_second: 25
 
 # Minimum milliseconds between /demo calls before rate limiting kicks in.
 # Set to 0 or less to disable demo rate limiting entirely. (Default: 0)

--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -129,7 +129,7 @@ packet_rate_limit:
   max_per_second: 25
 
 # Global server-wide new connections per second cap.
-# Limits total new TCP connections across ALL IPs per second.
+# Limits total new connections across ALL IPs per second.
 # Set max_per_second to 0 to disable. (Default: 0 = disabled)
 global_connection_rate:
   max_per_second: 5

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -52,6 +52,7 @@ class ClientManager:
             self.ipid = ipid
             self.version = ""
             self.software = ""
+            self.connection_time = time.time()
 
             self.first_joined = True
             self.joined = False

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -107,6 +107,22 @@ class ClientManager:
                     self.server.config["ooc_floodguard"]["times_per_interval"]
                 )
             ]
+            self.ic_counter = 0
+            self.ic_mute_time = 0
+            self.ic_time = [
+                x * self.server.config["ic_floodguard"]["interval_length"]
+                for x in range(
+                    self.server.config["ic_floodguard"]["times_per_interval"]
+                )
+            ]
+            self.cc_counter = 0
+            self.cc_mute_time = 0
+            self.cc_time = [
+                x * self.server.config["cc_floodguard"]["interval_length"]
+                for x in range(
+                    self.server.config["cc_floodguard"]["times_per_interval"]
+                )
+            ]
             # security stuff
             self.clientscon = 0
             self.gm_save_time = 0
@@ -1049,7 +1065,7 @@ class ClientManager:
                 < interval_length
             ):
                 self.wtce_mute_time = time.time()
-                return self.server.config["music_change_floodguard"]["mute_length"]
+                return self.server.config["wtce_floodguard"]["mute_length"]
             self.wtce_counter = (self.wtce_counter + 1) % times_per_interval
             self.wtce_time[self.wtce_counter] = time.time()
             return 0
@@ -1083,9 +1099,79 @@ class ClientManager:
                 < interval_length
             ):
                 self.ooc_mute_time = time.time()
-                return self.server.config["music_change_floodguard"]["mute_length"]
+                return self.server.config["ooc_floodguard"]["mute_length"]
             self.ooc_counter = (self.ooc_counter + 1) % times_per_interval
             self.ooc_time[self.ooc_counter] = time.time()
+            return 0
+
+        def ic_mute(self):
+            """
+            Check if the client can send IC messages or not.
+            :returns: how many seconds the client must wait to send IC
+            """
+            if self.is_mod or self in self.area.owners:
+                return 0
+
+            if self.ic_mute_time:
+                if (
+                    time.time() - self.ic_mute_time
+                    < self.server.config["ic_floodguard"]["mute_length"]
+                ):
+                    return self.server.config["ic_floodguard"]["mute_length"] - (
+                        time.time() - self.ic_mute_time
+                    )
+                else:
+                    self.ic_mute_time = 0
+            times_per_interval = self.server.config["ic_floodguard"][
+                "times_per_interval"
+            ]
+            interval_length = self.server.config["ic_floodguard"]["interval_length"]
+            if (
+                time.time()
+                - self.ic_time[
+                    (self.ic_counter - times_per_interval + 1) % times_per_interval
+                ]
+                < interval_length
+            ):
+                self.ic_mute_time = time.time()
+                return self.server.config["ic_floodguard"]["mute_length"]
+            self.ic_counter = (self.ic_counter + 1) % times_per_interval
+            self.ic_time[self.ic_counter] = time.time()
+            return 0
+
+        def cc_mute(self):
+            """
+            Check if the client can change character or not.
+            :returns: how many seconds the client must wait to change character
+            """
+            if self.is_mod or self in self.area.owners:
+                return 0
+
+            if self.cc_mute_time:
+                if (
+                    time.time() - self.cc_mute_time
+                    < self.server.config["cc_floodguard"]["mute_length"]
+                ):
+                    return self.server.config["cc_floodguard"]["mute_length"] - (
+                        time.time() - self.cc_mute_time
+                    )
+                else:
+                    self.cc_mute_time = 0
+            times_per_interval = self.server.config["cc_floodguard"][
+                "times_per_interval"
+            ]
+            interval_length = self.server.config["cc_floodguard"]["interval_length"]
+            if (
+                time.time()
+                - self.cc_time[
+                    (self.cc_counter - times_per_interval + 1) % times_per_interval
+                ]
+                < interval_length
+            ):
+                self.cc_mute_time = time.time()
+                return self.server.config["cc_floodguard"]["mute_length"]
+            self.cc_counter = (self.cc_counter + 1) % times_per_interval
+            self.cc_time[self.cc_counter] = time.time()
             return 0
 
         def reload_character(self):
@@ -2570,6 +2656,8 @@ class ClientManager:
         self.server = server
         self.cur_id = [i for i in range(self.server.config["playerlimit"])]
         self.delays = {}
+        # Per-IP connection rate limiting: {ipid: [timestamp, ...]}
+        self.connection_times = {}
 
     def set_spam_delay(self, ipid, spam_type, value):
         if not str(ipid) in self.delays:
@@ -2587,9 +2675,32 @@ class ClientManager:
         maxclients = self.server.config["multiclient_limit"]
         for c in self.server.client_manager.clients:
             if c.ipid == client.ipid:
-                if c.clientscon > maxclients:
+                if c.clientscon >= maxclients:
                     return False
         return True
+
+    def check_connection_rate(self, ipid):
+        """
+        Check if an IP is connecting too frequently.
+        :param ipid: the IP identifier
+        :returns: True if the connection should be rejected, False otherwise
+        """
+        config = self.server.config.get("connection_rate_limit", {})
+        max_conns = config.get("max_connections", 5)
+        interval = config.get("interval_length", 5)
+        if max_conns <= 0 or interval <= 0:
+            return False
+        now = time.time()
+        if ipid not in self.connection_times:
+            self.connection_times[ipid] = []
+        # Purge old timestamps outside the window
+        self.connection_times[ipid] = [
+            t for t in self.connection_times[ipid] if now - t < interval
+        ]
+        if len(self.connection_times[ipid]) >= max_conns:
+            return True
+        self.connection_times[ipid].append(now)
+        return False
 
     def new_client(self, transport):
         """

--- a/server/commands/character.py
+++ b/server/commands/character.py
@@ -100,6 +100,11 @@ def ooc_cmd_switch(client, arg):
     automatically reassigned a character.
     Usage: /switch <name>
     """
+    if client.cc_mute():
+        client.send_ooc(
+            f"You are changing characters too fast. Please try again after {int(client.cc_mute())} seconds."
+        )
+        return
     if len(arg) == 0:
         client.char_select()
         return
@@ -351,6 +356,11 @@ def ooc_cmd_randomchar(client):
     Select a random character.
     Usage: /randomchar
     """
+    if client.cc_mute():
+        client.send_ooc(
+            f"You are changing characters too fast. Please try again after {int(client.cc_mute())} seconds."
+        )
+        return
     if len(client.charcurse) > 0:
         free_id = random.choice(client.charcurse)
     else:

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -31,6 +31,9 @@ class AOProtocol(asyncio.Protocol):
         self.client = None
         self.buffer = ""
         self.ping_timeout = None
+        # Packet rate limiting
+        self._packet_times = []
+        self._packet_kicked = False
 
     def data_received(self, data):
         """Handles any data received from the network.
@@ -43,6 +46,26 @@ class AOProtocol(asyncio.Protocol):
         """
         buf = data
         ipid = self.client.ipid
+
+        # Packet rate limiting
+        config = self.server.config.get("packet_rate_limit", {})
+        max_per_second = config.get("max_per_second", 20)
+        if max_per_second > 0 and not self._packet_kicked:
+            now = time.time()
+            self._packet_times.append(now)
+            # Purge timestamps older than 1 second
+            self._packet_times = [t for t in self._packet_times if now - t < 1.0]
+            if len(self._packet_times) > max_per_second:
+                logger.warning(
+                    "Packet rate limit exceeded from %s (%d packets/sec)",
+                    ipid, len(self._packet_times),
+                )
+                self.client.send_ooc(
+                    "You are sending packets too fast. You have been disconnected."
+                )
+                self._packet_kicked = True
+                self.client.disconnect()
+                return
 
         if buf is None:
             buf = b""
@@ -90,6 +113,14 @@ class AOProtocol(asyncio.Protocol):
         except ClientError:
             print(traceback.format_exc())
             transport.close()
+            return
+
+        if self.server.client_manager.check_connection_rate(self.client.ipid):
+            self.client.send_command(
+                "BD",
+                "Connection rate limit exceeded. Please try again later.",
+            )
+            self.client.disconnect()
             return
 
         if not self.server.client_manager.new_client_preauth(self.client):
@@ -339,6 +370,11 @@ class AOProtocol(asyncio.Protocol):
             return
         elif not self.client.is_checked:
             return
+        if self.client.cc_mute():
+            self.client.send_ooc(
+                f"You are changing characters too fast. Please try again after {int(self.client.cc_mute())} seconds."
+            )
+            return
 
         cid = args[1]
         try:
@@ -356,6 +392,11 @@ class AOProtocol(asyncio.Protocol):
             return
         if self.client.is_muted:  # Checks to see if the client has been muted by a mod
             self.client.send_ooc("You are muted by a moderator.")
+            return
+        if self.client.ic_mute():
+            self.client.send_ooc(
+                f"You are sending messages too fast. Please try again after {int(self.client.ic_mute())} seconds."
+            )
             return
 
         showname = ""

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -108,6 +108,24 @@ class AOProtocol(asyncio.Protocol):
 
         :param transport: the transport object
         """
+        # Global connection rate limiting (not per-IP)
+        config = self.server.config.get("global_connection_rate", {})
+        max_per_second = config.get("max_per_second", 0)
+        if max_per_second > 0:
+            now = time.time()
+            if not hasattr(self.server, "_conn_times"):
+                self.server._conn_times = []
+            self.server._conn_times.append(now)
+            self.server._conn_times = [t for t in self.server._conn_times if now - t < 1.0]
+            if len(self.server._conn_times) > max_per_second:
+                logger.warning(
+                    "Global connection rate limit exceeded (%d connections/sec)",
+                    len(self.server._conn_times),
+                )
+                transport.write(b"BD#Server is experiencing high connection volume. Please try again later.#%")
+                transport.close()
+                return
+
         try:
             self.client = self.server.new_client(transport)
         except ClientError:
@@ -370,6 +388,14 @@ class AOProtocol(asyncio.Protocol):
             return
         elif not self.client.is_checked:
             return
+        min_age = self.server.config.get("min_connection_age", {}).get("before_cc", 0)
+        if min_age > 0 and not self.client.is_mod and self.client not in self.client.area.owners:
+            elapsed = time.time() - self.client.connection_time
+            if elapsed < min_age:
+                self.client.send_ooc(
+                    f"Please wait {int(min_age - elapsed) + 1} more seconds before changing characters."
+                )
+                return
         if self.client.cc_mute():
             self.client.send_ooc(
                 f"You are changing characters too fast. Please try again after {int(self.client.cc_mute())} seconds."
@@ -390,6 +416,14 @@ class AOProtocol(asyncio.Protocol):
         """
         if not self.client.is_checked:
             return
+        min_age = self.server.config.get("min_connection_age", {}).get("before_ic", 0)
+        if min_age > 0 and not self.client.is_mod and self.client not in self.client.area.owners:
+            elapsed = time.time() - self.client.connection_time
+            if elapsed < min_age:
+                self.client.send_ooc(
+                    f"Please wait {int(min_age - elapsed) + 1} more seconds before sending messages."
+                )
+                return
         if self.client.is_muted:  # Checks to see if the client has been muted by a mod
             self.client.send_ooc("You are muted by a moderator.")
             return

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -378,6 +378,15 @@ class TsuServer3:
             self.config["packet_rate_limit"] = {
                 "max_per_second": 0,
             }
+        if "global_connection_rate" not in self.config:
+            self.config["global_connection_rate"] = {
+                "max_per_second": 0,
+            }
+        if "min_connection_age" not in self.config:
+            self.config["min_connection_age"] = {
+                "before_ic": 0,
+                "before_cc": 0,
+            }
 
         if "demo_rate_limit_ms" not in self.config:
             self.config["demo_rate_limit_ms"] = 0

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -357,6 +357,27 @@ class TsuServer3:
                 "interval_length": 0,
                 "mute_length": 0,
             }
+        if "ic_floodguard" not in self.config:
+            self.config["ic_floodguard"] = {
+                "times_per_interval": 1,
+                "interval_length": 0,
+                "mute_length": 0,
+            }
+        if "cc_floodguard" not in self.config:
+            self.config["cc_floodguard"] = {
+                "times_per_interval": 1,
+                "interval_length": 0,
+                "mute_length": 0,
+            }
+        if "connection_rate_limit" not in self.config:
+            self.config["connection_rate_limit"] = {
+                "max_connections": 0,
+                "interval_length": 10,
+            }
+        if "packet_rate_limit" not in self.config:
+            self.config["packet_rate_limit"] = {
+                "max_per_second": 0,
+            }
 
         if "demo_rate_limit_ms" not in self.config:
             self.config["demo_rate_limit_ms"] = 0

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -730,9 +730,13 @@ def test_demo_broadcasts_to_real_clients(monkeypatch):
         config={
             "playerlimit": 64,
             "hostname": "test",
-            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1},
-            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1},
-            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "ic_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "cc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "connection_rate_limit": {"max_connections": 0, "interval_length": 10},
+            "packet_rate_limit": {"max_per_second": 0},
         },
         command_aliases={},
     )
@@ -796,9 +800,13 @@ def _make_server():
     return SimpleNamespace(
         hub_manager=FakeHubManager(),
         config={
-            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1},
-            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1},
-            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "ic_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "cc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "connection_rate_limit": {"max_connections": 0, "interval_length": 10},
+            "packet_rate_limit": {"max_per_second": 0},
         },
     )
 
@@ -883,9 +891,13 @@ def test_executor_permissions_gm_only(monkeypatch):
         config={
             "playerlimit": 64,
             "hostname": "test",
-            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1},
-            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1},
-            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "ic_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "cc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "connection_rate_limit": {"max_connections": 0, "interval_length": 10},
+            "packet_rate_limit": {"max_per_second": 0},
         },
         command_aliases={},
     )
@@ -940,9 +952,13 @@ def test_executor_invisible_to_gm_lifecycle(monkeypatch):
         config={
             "playerlimit": 64,
             "hostname": "test",
-            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1},
-            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1},
-            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "ic_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "cc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "connection_rate_limit": {"max_connections": 0, "interval_length": 10},
+            "packet_rate_limit": {"max_per_second": 0},
         },
         command_aliases={},
     )
@@ -988,9 +1004,13 @@ def _server_with_client_manager():
         config={
             "playerlimit": 64,
             "hostname": "test",
-            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1},
-            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1},
-            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "ic_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "cc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
+            "connection_rate_limit": {"max_connections": 0, "interval_length": 10},
+            "packet_rate_limit": {"max_per_second": 0},
         },
         command_aliases={},
         player_state_observer=SimpleNamespace(

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -737,6 +737,8 @@ def test_demo_broadcasts_to_real_clients(monkeypatch):
             "cc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
             "connection_rate_limit": {"max_connections": 0, "interval_length": 10},
             "packet_rate_limit": {"max_per_second": 0},
+            "global_connection_rate": {"max_per_second": 0},
+            "min_connection_age": {"before_ic": 0, "before_cc": 0},
         },
         command_aliases={},
     )
@@ -807,6 +809,8 @@ def _make_server():
             "cc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
             "connection_rate_limit": {"max_connections": 0, "interval_length": 10},
             "packet_rate_limit": {"max_per_second": 0},
+            "global_connection_rate": {"max_per_second": 0},
+            "min_connection_age": {"before_ic": 0, "before_cc": 0},
         },
     )
 
@@ -898,6 +902,8 @@ def test_executor_permissions_gm_only(monkeypatch):
             "cc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
             "connection_rate_limit": {"max_connections": 0, "interval_length": 10},
             "packet_rate_limit": {"max_per_second": 0},
+            "global_connection_rate": {"max_per_second": 0},
+            "min_connection_age": {"before_ic": 0, "before_cc": 0},
         },
         command_aliases={},
     )
@@ -959,6 +965,8 @@ def test_executor_invisible_to_gm_lifecycle(monkeypatch):
             "cc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
             "connection_rate_limit": {"max_connections": 0, "interval_length": 10},
             "packet_rate_limit": {"max_per_second": 0},
+            "global_connection_rate": {"max_per_second": 0},
+            "min_connection_age": {"before_ic": 0, "before_cc": 0},
         },
         command_aliases={},
     )
@@ -1011,6 +1019,8 @@ def _server_with_client_manager():
             "cc_floodguard": {"interval_length": 1, "times_per_interval": 1, "mute_length": 0},
             "connection_rate_limit": {"max_connections": 0, "interval_length": 10},
             "packet_rate_limit": {"max_per_second": 0},
+            "global_connection_rate": {"max_per_second": 0},
+            "min_connection_age": {"before_ic": 0, "before_cc": 0},
         },
         command_aliases={},
         player_state_observer=SimpleNamespace(


### PR DESCRIPTION
Add global connection cap and connection age gate. 
- Global new-connections-per-second cap: server-wide limit on accepted connections, if the server is overloaded refuse new connections rather than allowing the server to die.
- Minimum connection age gate: clients must be connected for N seconds before they can send IC messages or change characters. Mods/CMs exempt. 

Add DOS protection: IC/CC flood guards, connection rate limiter, packet throttle

Bug fixes:
- Fix WTCE flood guard reading music_change_floodguard mute_length instead of wtce_floodguard
- Fix OOC flood guard reading music_change_floodguard mute_length instead of ooc_floodguard
- Fix multiclient limit check (> should be >=)

New protections:
- IC message flood guard (ic_floodguard): prevents rapid IC spam
- Character change flood guard (cc_floodguard): prevents rapid CC spam. Also enforced on /switch and /randomchar commands
- Per-IP connection rate limiter (connection_rate_limit): throttles rapid connect/disconnect cycles from the same IP
- Global packet-per-second throttle (packet_rate_limit): hard per-client cap on packets/sec to prevent flooding

All configurable in config.yaml