### PR TITLE
Security hardening: fix 5 reported vulnerabilities

### DIFF
--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -33,6 +33,11 @@ modpass:
   Admin:
     password: mod
 
+# Cooldown (in milliseconds) after a failed /login attempt before another
+# attempt is allowed from the same IPID. Throttles mod-password brute force.
+# Set to 0 to disable. (Default: 3000)
+login_cooldown_ms: 3000
+
 # Password to use the /restart command
 restartpass: restart
 

--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -188,7 +188,7 @@ class AreaManager:
         """Load the character list from a YAML file."""
         if self.char_list_ref == charlist:
             return
-        charlist = derelative(charlist.lower())
+        charlist = derelative(charlist.lower()).replace("/", "").replace("\\", "")
         self.char_list_ref = charlist
         if charlist != "":
             new_chars = None

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -2584,7 +2584,8 @@ class ClientManager:
 
         def set_login_delay(self):
             """Begin the login cooldown (throttles brute-force attempts)."""
-            self.login_time = round(time.time() * 1000.0 + 3000)
+            cooldown_ms = self.server.config.get("login_cooldown_ms", 3000)
+            self.login_time = round(time.time() * 1000.0 + cooldown_ms)
 
         def can_attempt_login(self):
             """Whether or not the client can currently attempt to log in."""

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -3,6 +3,7 @@ import string
 import time
 import math
 import os
+import hmac
 import arrow
 from heapq import heappop, heappush
 
@@ -2252,9 +2253,14 @@ class ClientManager:
             """
             modpasses = self.server.config["modpass"]
             if isinstance(modpasses, dict):
-                matches = [k for k in modpasses if modpasses[k]
-                           ["password"] == password]
-            elif modpasses == password:
+                matches = [
+                    k
+                    for k in modpasses
+                    if hmac.compare_digest(
+                        str(modpasses[k]["password"]), str(password)
+                    )
+                ]
+            elif hmac.compare_digest(str(modpasses), str(password)):
                 matches = ["default"]
             else:
                 matches = []
@@ -2299,6 +2305,14 @@ class ClientManager:
         @sfx_time.setter
         def sfx_time(self, value):
             self.server.client_manager.set_spam_delay(self.ipid, "sfx", value)
+
+        @property
+        def login_time(self):
+            return self.server.client_manager.get_spam_delay(self.ipid, "login")
+
+        @login_time.setter
+        def login_time(self, value):
+            self.server.client_manager.set_spam_delay(self.ipid, "login", value)
 
         @property
         def ip(self):
@@ -2567,6 +2581,14 @@ class ClientManager:
         def can_call_mod(self):
             """Whether or not the client can currently call mod."""
             return (time.time() * 1000.0 - self.mod_call_time) > 0
+
+        def set_login_delay(self):
+            """Begin the login cooldown (throttles brute-force attempts)."""
+            self.login_time = round(time.time() * 1000.0 + 3000)
+
+        def can_attempt_login(self):
+            """Whether or not the client can currently attempt to log in."""
+            return (time.time() * 1000.0 - self.login_time) > 0
 
         def set_case_call_delay(self):
             """Begin the case announcement cooldown."""

--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -297,10 +297,15 @@ def ooc_cmd_login(client, password):
     """
     if not password:
         raise ArgumentError("You must specify the password.")
+    if not client.can_attempt_login():
+        raise ClientError(
+            "Too many failed login attempts. Please wait a moment and try again."
+        )
     login_name = None
     try:
         login_name = client.auth_mod(password)
     except ClientError:
+        client.set_login_delay()
         database.log_misc("login.invalid", client)
         raise
 

--- a/server/commands/battle.py
+++ b/server/commands/battle.py
@@ -132,6 +132,7 @@ def ooc_cmd_info_fighter(client):
         client.send_ooc("You have to choose a fighter first!")
 
 
+@mod_only(hub_owners=True)
 @command(
     Arg("name", help="fighter name"),
     Arg("hp", float),
@@ -162,6 +163,12 @@ def ooc_cmd_create_fighter(client, name, hp, mana, atk, defe, spa, spd, spe):
         return
 
     fighter_list = os.listdir("storage/battlesystem")
+
+    if len(fighter_list) >= 1000:
+        client.send_ooc(
+            "Fighter storage is full! Please contact the server host to resolve this issue."
+        )
+        return
 
     path = derelative(name.lower())
     if f"{path}.yaml" in fighter_list:

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -97,9 +97,8 @@ class AOProtocol(asyncio.Protocol):
                 logger.debug(
                     "Unknown incoming message from %s: %s", ipid, msg)
             except Exception:
-                traceback_string = traceback.format_exc()
-                print(traceback_string)
-                self.client.send_command("KK", f'An error has occurred!\n{traceback_string}\n\nPlease contact the server owner to report this issue.')
+                logger.exception("Unhandled exception processing packet from %s", ipid)
+                self.client.send_command("KK", "An internal server error occurred. Please reconnect.")
                 self.client.disconnect()
                 raise
 

--- a/server/network/webhooks.py
+++ b/server/network/webhooks.py
@@ -2,6 +2,7 @@ from time import gmtime, strftime
 
 import requests
 import json
+import asyncio
 
 from server import database
 
@@ -43,20 +44,36 @@ class Webhooks:
             embed["title"] = title
             embed["color"] = color
             data["embeds"].append(embed)
-        result = requests.post(
-            url, data=json.dumps(data), headers={"Content-Type": "application/json"}
-        )
-        try:
-            result.raise_for_status()
-        except requests.exceptions.HTTPError as err:
-            database.log_misc("webhook.err", data=err.response.status_code)
-        else:
-            database.log_misc(
-                "webhook.ok",
-                data="successfully delivered payload, code {}".format(
-                    result.status_code
-                ),
+        def _post():
+            return requests.post(
+                url,
+                data=json.dumps(data),
+                headers={"Content-Type": "application/json"},
+                timeout=5,
             )
+
+        loop = asyncio.get_running_loop()
+        future = loop.run_in_executor(None, _post)
+
+        def _handle_result(fut):
+            try:
+                result = fut.result()
+            except Exception as err:
+                database.log_misc("webhook.err", data=str(err))
+                return
+            try:
+                result.raise_for_status()
+            except requests.exceptions.HTTPError as err:
+                database.log_misc("webhook.err", data=err.response.status_code)
+            else:
+                database.log_misc(
+                    "webhook.ok",
+                    data="successfully delivered payload, code {}".format(
+                        result.status_code
+                    ),
+                )
+
+        future.add_done_callback(_handle_result)
 
     def modcall(self, char, ipid, area, reason=None):
         is_enabled = self.server.config["modcall_webhook"]["enabled"]

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -367,6 +367,8 @@ class TsuServer3:
                 "before_ic": 0,
                 "before_cc": 0,
             }
+        if "login_cooldown_ms" not in self.config:
+            self.config["login_cooldown_ms"] = 3000
 
         if "demo_rate_limit_ms" not in self.config:
             self.config["demo_rate_limit_ms"] = 0


### PR DESCRIPTION
- aoprotocol: log unhandled packet exceptions server-side and send a generic disconnect instead of leaking the full traceback to clients (Finding 1)

- area_manager: strip path separators after derelative() to fully block /charlist path traversal (Finding 2)

- battle: require mod/hub-owner auth for /create_fighter and cap stored fighters to prevent unauthenticated disk exhaustion (Finding 3)

- webhooks: run blocking requests.post with a timeout in a thread-pool executor so webhook delivery cannot freeze the event loop (Finding 4)

- client_manager/admin: use hmac.compare_digest for mod password comparison and add a login cooldown to throttle brute force (Finding 5)