### PR TITLE
Upgrade urllib3 to >=2.7.0 to fix decompression bomb via HTTP redirec…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ requests==2.31.0
 six==1.16.0
 timeparse-plus==1.2.0
 types-python-dateutil==2.8.19.14
-urllib3==2.1.0
+urllib3>=2.7.0
 websockets==12.0
 yarl==1.20.0


### PR DESCRIPTION
Upgrades `urllib3` from the vulnerable `2.1.0` to `>=2.7.0` to resolve the decompression-bomb vulnerability triggered via HTTP redirects in the streaming API. No other dependencies or code paths were changed.
